### PR TITLE
Add Income Sources Endpoints and backend tests

### DIFF
--- a/backend/__tests__/income.test.js
+++ b/backend/__tests__/income.test.js
@@ -1,0 +1,191 @@
+jest.mock('../db', () => ({ query: jest.fn() }))
+jest.mock('../supabaseClient', () => ({ signUp: jest.fn(), signIn: jest.fn() }))
+jest.mock('../middleware/auth', () =>
+  jest.fn((req, res, next) => { req.user = { id: 'uid', email: 'a@b.com' }; next() })
+)
+
+const request = require('supertest')
+const app = require('../index')
+const db = require('../db')
+
+beforeEach(() => db.query.mockClear())
+
+describe('POST /income', () => {
+  const row = { id: 1, user_id: 'uid', source_id: 'src-1', amount: '3000.00', month: '2026-03-01', notes: null, created_at: '2026-03-01T10:00:00Z' }
+
+  it('creates income entry and strips user_id from response', async () => {
+    db.query.mockResolvedValueOnce({ rows: [row] })
+    const res = await request(app).post('/income').send({ amount: 3000, month: '2026-03-01' })
+    expect(res.status).toBe(201)
+    expect(res.body).toMatchObject({ id: 1, source_id: 'src-1', amount: '3000.00', month: '2026-03-01' })
+    expect(res.body).not.toHaveProperty('user_id')
+  })
+
+  it('accepts optional source_id and notes', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, notes: 'Bonus included' }] })
+    const res = await request(app).post('/income').send({ source_id: 'src-1', amount: 3000, month: '2026-03-01', notes: 'Bonus included' })
+    expect(res.status).toBe(201)
+    expect(res.body.notes).toBe('Bonus included')
+  })
+
+  it('rejects request without amount', async () => {
+    const res = await request(app).post('/income').send({ month: '2026-03-01' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('amount and month are required')
+  })
+
+  it('rejects request without month', async () => {
+    const res = await request(app).post('/income').send({ amount: 3000 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('amount and month are required')
+  })
+
+  it('returns 500 on db failure', async () => {
+    db.query.mockRejectedValueOnce(new Error())
+    const res = await request(app).post('/income').send({ amount: 3000, month: '2026-03-01' })
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to create income')
+  })
+})
+
+describe('GET /income', () => {
+  it('returns all income entries and strips user_id from each', async () => {
+    const rows = [
+      { id: 1, user_id: 'uid', source_id: 'src-1', amount: '3000.00', month: '2026-03-01', notes: null, source_name: 'Salary', source_icon: '💼' },
+      { id: 2, user_id: 'uid', source_id: 'src-2', amount: '500.00', month: '2026-02-01', notes: 'Side project', source_name: 'Freelance', source_icon: '💻' },
+    ]
+    db.query.mockResolvedValueOnce({ rows })
+    const res = await request(app).get('/income')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(2)
+    expect(res.body[0]).toMatchObject({ id: 1, source_id: 'src-1', amount: '3000.00', source_name: 'Salary' })
+    expect(res.body[1]).toMatchObject({ id: 2, source_id: 'src-2', notes: 'Side project', source_name: 'Freelance' })
+    res.body.forEach(i => expect(i).not.toHaveProperty('user_id'))
+  })
+
+  it('returns empty array when user has no income', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    const res = await request(app).get('/income')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual([])
+  })
+
+  it('returns 500 on db failure', async () => {
+    db.query.mockRejectedValueOnce(new Error())
+    const res = await request(app).get('/income')
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to fetch income')
+  })
+})
+
+describe('POST /income/get', () => {
+  const row = { id: 1, user_id: 'uid', source_id: 'src-1', amount: '3000.00', month: '2026-03-01', notes: null, source_name: 'Salary', source_icon: '💼' }
+
+  it('returns income entry and strips user_id from response', async () => {
+    db.query.mockResolvedValueOnce({ rows: [row] })
+    const res = await request(app).post('/income/get').send({ income_id: 1 })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ id: 1, source_id: 'src-1', amount: '3000.00', source_name: 'Salary' })
+    expect(res.body).not.toHaveProperty('user_id')
+  })
+
+  it('rejects request without income_id', async () => {
+    const res = await request(app).post('/income/get').send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('income_id required')
+  })
+
+  it('returns 404 when income entry does not exist', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    const res = await request(app).post('/income/get').send({ income_id: 999 })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('Income not found')
+  })
+
+  it('returns 500 on db failure', async () => {
+    db.query.mockRejectedValueOnce(new Error())
+    const res = await request(app).post('/income/get').send({ income_id: 1 })
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to fetch income')
+  })
+})
+
+describe('POST /income/update', () => {
+  const row = { id: 1, user_id: 'uid', source_id: 'src-1', amount: '3500.00', month: '2026-03-01', notes: null }
+
+  it('updates amount and strips user_id from response', async () => {
+    db.query.mockResolvedValueOnce({ rows: [row] })
+    const res = await request(app).post('/income/update').send({ income_id: 1, amount: 3500 })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ id: 1, amount: '3500.00' })
+    expect(res.body).not.toHaveProperty('user_id')
+  })
+
+  it('updates source_id field', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, source_id: 'src-2' }] })
+    const res = await request(app).post('/income/update').send({ income_id: 1, source_id: 'src-2' })
+    expect(res.status).toBe(200)
+    expect(res.body.source_id).toBe('src-2')
+  })
+
+  it('updates multiple fields at once', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, notes: 'Raise applied', month: '2026-04-01' }] })
+    const res = await request(app).post('/income/update').send({ income_id: 1, notes: 'Raise applied', month: '2026-04-01' })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ notes: 'Raise applied', month: '2026-04-01' })
+  })
+
+  it('rejects update without income_id', async () => {
+    const res = await request(app).post('/income/update').send({ amount: 3500 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('income_id required')
+  })
+
+  it('rejects update when no fields are provided', async () => {
+    const res = await request(app).post('/income/update').send({ income_id: 1 })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('No fields provided to update')
+  })
+
+  it('returns 404 when income entry does not exist', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    const res = await request(app).post('/income/update').send({ income_id: 999, amount: 100 })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('Income not found')
+  })
+
+  it('returns 500 on db failure', async () => {
+    db.query.mockRejectedValueOnce(new Error())
+    const res = await request(app).post('/income/update').send({ income_id: 1, amount: 100 })
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to update income')
+  })
+})
+
+describe('POST /income/delete', () => {
+  it('deletes income entry and returns 204', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ id: 1 }] })
+    const res = await request(app).post('/income/delete').send({ income_id: 1 })
+    expect(res.status).toBe(204)
+  })
+
+  it('rejects delete without income_id', async () => {
+    const res = await request(app).post('/income/delete').send({})
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('income_id required')
+  })
+
+  it('returns 404 when income entry does not exist', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    const res = await request(app).post('/income/delete').send({ income_id: 999 })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('Income not found')
+  })
+
+  it('returns 500 on db failure', async () => {
+    db.query.mockRejectedValueOnce(new Error())
+    const res = await request(app).post('/income/delete').send({ income_id: 1 })
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to delete income')
+  })
+})

--- a/backend/__tests__/income.test.js
+++ b/backend/__tests__/income.test.js
@@ -78,6 +78,27 @@ describe('GET /income', () => {
   })
 })
 
+describe('GET /income/categories', () => {
+  it('returns all income categories', async () => {
+    const rows = [
+      { id: 'src-1', name: 'Salary', icon: '💼' },
+      { id: 'src-2', name: 'Freelance', icon: '💻' },
+    ]
+    db.query.mockResolvedValueOnce({ rows })
+    const res = await request(app).get('/income/categories')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(2)
+    expect(res.body[0]).toMatchObject({ id: 'src-1', name: 'Salary', icon: '💼' })
+  })
+
+  it('returns 500 on db failure', async () => {
+    db.query.mockRejectedValueOnce(new Error())
+    const res = await request(app).get('/income/categories')
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to fetch income categories')
+  })
+})
+
 describe('POST /income/get', () => {
   const row = { id: 1, user_id: 'uid', source_id: 'src-1', amount: '3000.00', month: '2026-03-01', notes: null, source_name: 'Salary', source_icon: '💼' }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -8,6 +8,7 @@ app.use(express.json())
 app.get('/', (req, res) => res.json({ status: 'ok' }))
 app.use('/', require('./routes/auth'))
 app.use('/expenses', require('./routes/expenses'))
+app.use('/income', require('./routes/income'))
 
 module.exports = app
 

--- a/backend/routes/income.js
+++ b/backend/routes/income.js
@@ -1,0 +1,98 @@
+const { Router } = require('express')
+const db = require('../db')
+const authenticate = require('../middleware/auth')
+
+const router = Router()
+router.use(authenticate)
+
+router.post('/', async (req, res) => {
+  const { source_id, amount, month, notes } = req.body
+  if (!amount || !month) return res.status(400).json({ error: 'amount and month are required' })
+  try {
+    const { rows } = await db.query(
+      `INSERT INTO public.income (user_id, source_id, amount, month, notes)
+       VALUES ($1, $2, $3, $4, $5) RETURNING *`,
+      [req.user.id, source_id ?? null, amount, month, notes ?? null]
+    )
+    const { user_id, ...income } = rows[0]
+    res.status(201).json(income)
+  } catch {
+    res.status(500).json({ error: 'Failed to create income' })
+  }
+})
+
+router.get('/', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT i.*, s.name AS source_name, s.icon AS source_icon
+       FROM public.income i
+       LEFT JOIN public.income_sources s ON i.source_id = s.id
+       WHERE i.user_id = $1
+       ORDER BY i.month DESC, i.created_at DESC`,
+      [req.user.id]
+    )
+    res.json(rows.map(({ user_id, ...i }) => i))
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch income' })
+  }
+})
+
+router.post('/get', async (req, res) => {
+  const { income_id } = req.body
+  if (!income_id) return res.status(400).json({ error: 'income_id required' })
+  try {
+    const { rows } = await db.query(
+      `SELECT i.*, s.name AS source_name, s.icon AS source_icon
+       FROM public.income i
+       LEFT JOIN public.income_sources s ON i.source_id = s.id
+       WHERE i.id = $1 AND i.user_id = $2`,
+      [income_id, req.user.id]
+    )
+    if (!rows.length) return res.status(404).json({ error: 'Income not found' })
+    const { user_id, ...income } = rows[0]
+    res.json(income)
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch income' })
+  }
+})
+
+router.post('/update', async (req, res) => {
+  const { income_id, source_id, amount, month, notes } = req.body
+  if (!income_id) return res.status(400).json({ error: 'income_id required' })
+
+  const entries = Object.entries({ source_id, amount, month, notes }).filter(([, v]) => v !== undefined)
+  if (!entries.length) return res.status(400).json({ error: 'No fields provided to update' })
+
+  const fields = entries.map(([k], i) => `${k} = $${i + 1}`)
+  const values = [...entries.map(([, v]) => v), income_id, req.user.id]
+  const n = entries.length
+
+  try {
+    const { rows } = await db.query(
+      `UPDATE public.income SET ${fields.join(', ')} WHERE id = $${n + 1} AND user_id = $${n + 2} RETURNING *`,
+      values
+    )
+    if (!rows.length) return res.status(404).json({ error: 'Income not found' })
+    const { user_id, ...income } = rows[0]
+    res.json(income)
+  } catch {
+    res.status(500).json({ error: 'Failed to update income' })
+  }
+})
+
+router.post('/delete', async (req, res) => {
+  const { income_id } = req.body
+  if (!income_id) return res.status(400).json({ error: 'income_id required' })
+  try {
+    const { rows } = await db.query(
+      `DELETE FROM public.income WHERE id = $1 AND user_id = $2 RETURNING id`,
+      [income_id, req.user.id]
+    )
+    if (!rows.length) return res.status(404).json({ error: 'Income not found' })
+    res.status(204).send()
+  } catch {
+    res.status(500).json({ error: 'Failed to delete income' })
+  }
+})
+
+module.exports = router

--- a/backend/routes/income.js
+++ b/backend/routes/income.js
@@ -37,6 +37,15 @@ router.get('/', async (req, res) => {
   }
 })
 
+router.get('/categories', async (req, res) => {
+  try {
+    const { rows } = await db.query(`SELECT id, name, icon FROM public.income_sources ORDER BY name ASC`)
+    res.json(rows)
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch income categories' })
+  }
+})
+
 router.post('/get', async (req, res) => {
   const { income_id } = req.body
   if (!income_id) return res.status(400).json({ error: 'income_id required' })

--- a/supabase/migrations/20260308000000_add_income_category.sql
+++ b/supabase/migrations/20260308000000_add_income_category.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS public.income_sources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  icon TEXT
+);
+
+INSERT INTO public.income_sources (name, icon) VALUES
+  ('Salary', '💼'),
+  ('Freelance', '💻'),
+  ('Part-time', '⏱️'),
+  ('Business', '🏢'),
+  ('Investment', '📈'),
+  ('Rental', '🏠'),
+  ('Gift', '🎁'),
+  ('Other', '💰')
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE public.income
+  DROP COLUMN IF EXISTS source;
+
+ALTER TABLE public.income
+  ADD COLUMN IF NOT EXISTS source_id UUID REFERENCES public.income_sources(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_income_user_source_id ON public.income (user_id, source_id);


### PR DESCRIPTION
# PR: Add Income Sources Endpoints and backend tests

- Implemented income endpoints:
  - `POST /income` — insert income source (supports optional fields `source_id`, `notes`)
  - `GET /income` — list all user income sources
  - `POST /income/get` — fetch single income by `income_id`
  - `POST /income/update` — update fields (requires `income_id`)
  - `POST /income/delete` — delete (requires `income_id`)
  - `GET /income/categories` — list income categories 

- Added database migration:
  - `supabase/migrations/20260308000000_add_income_category.sql` — creates `income_sources` table, then inserts data for different categories of income

- Tests:
  - tests in `backend/__tests__/income.test.js` covering endpoints in income.js
 
Related to #8 
Related to #4