### PR TITLE
Fix budget threshold equality, alert logic, and align demo setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,29 @@ cd product-proposal
 
 **2. Install dependencies**
 ```bash
+cd nextjs
 npm install
 ```
 
 **3. Set up environment variables**
 
-Create a `.env.local` file in the root folder and add your Supabase credentials:
+Create a `.env.local` file in the `nextjs/` folder and add the server-side environment variables used by the app:
 ```
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+SUPABASE_URL=your_supabase_url
+SUPABASE_ANON_KEY=your_supabase_anon_key
+DATABASE_URL=your_database_connection_string
 ```
 
-
+`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are not enough for the current implementation because the API routes and shared server code read `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `DATABASE_URL`.
 
 **4. Start the app**
 ```bash
 npm run dev
+```
+
+**5. Verify the production build**
+```bash
+npm run build
 ```
 
 

--- a/nextjs/__tests__/budget.test.js
+++ b/nextjs/__tests__/budget.test.js
@@ -122,13 +122,31 @@ describe('GET /api/budget', () => {
 describe('POST /api/budget', () => {
   it('upserts a monthly budget and returns notified when spending reaches the limit', async () => {
     budget.upsertMonthlyBudget.mockResolvedValueOnce({ month: '2026-03-01', monthly_limit: '100.00', notified: false })
-    budget.evaluateThresholdForMonth.mockResolvedValueOnce({ notified: true })
+    budget.evaluateThresholdForMonth.mockResolvedValueOnce({
+      notified: true,
+      budget_alert: {
+        month: '2026-03-01',
+        monthly_limit: '100.00',
+        total_expenses: '100.00',
+        threshold_exceeded: true,
+      },
+    })
     await testApiHandler({
       appHandler: budgetHandler,
       async test({ fetch }) {
         const res = await fetch(post({ month: '2026-03-01', monthly_limit: 100 }))
         expect(res.status).toBe(200)
-        expect(await res.json()).toEqual({ month: '2026-03-01', monthly_limit: '100.00', notified: true })
+        expect(await res.json()).toEqual({
+          month: '2026-03-01',
+          monthly_limit: '100.00',
+          notified: true,
+          budget_alert: {
+            month: '2026-03-01',
+            monthly_limit: '100.00',
+            total_expenses: '100.00',
+            threshold_exceeded: true,
+          },
+        })
       }
     })
   })
@@ -244,7 +262,7 @@ describe('budget helper threshold boundary', () => {
     })
   })
 
-  it('triggers a budget alert when spending reaches the limit for the first time', async () => {
+  it('triggers a budget alert when spending reaches the limit', async () => {
     db.query
       .mockResolvedValueOnce({
         rows: [{ month: '2026-03-01', monthly_limit: '100.00', notified: false }]
@@ -277,5 +295,31 @@ describe('budget helper threshold boundary', () => {
       expect.stringContaining('UPDATE public.budget_thresholds'),
       ['uid', '2026-03-01', true]
     )
+  })
+
+  it('does not return a new budget alert when already over the limit and already notified', async () => {
+    db.query
+      .mockResolvedValueOnce({
+        rows: [{ month: '2026-03-01', monthly_limit: '100.00', notified: true }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{ total_expenses: '120.00' }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{ total_income: '0.00' }]
+      })
+
+    const result = await actualBudget.evaluateThresholdForMonth('uid', '2026-03-25')
+
+    expect(result).toEqual({
+      month: '2026-03-01',
+      monthly_limit: '100.00',
+      total_expenses: '120.00',
+      threshold_exceeded: true,
+      notified: true,
+      alertTriggered: false,
+      budget_alert: null,
+    })
+    expect(db.query).toHaveBeenCalledTimes(3)
   })
 })

--- a/nextjs/__tests__/budget.test.js
+++ b/nextjs/__tests__/budget.test.js
@@ -13,6 +13,7 @@ const { NextResponse } = require('next/server')
 const { authenticate } = require('@/lib/auth')
 const db = require('@/lib/db')
 const budget = require('@/lib/budget')
+const actualBudget = jest.requireActual('@/lib/budget')
 const budgetHandler = require('@/app/api/budget/route')
 const summaryHandler = require('@/app/api/budget/summary/route')
 const breakdownHandler = require('@/app/api/expenses/breakdown/route')
@@ -119,7 +120,7 @@ describe('GET /api/budget', () => {
 })
 
 describe('POST /api/budget', () => {
-  it('upserts a monthly budget and returns the latest notification state', async () => {
+  it('upserts a monthly budget and returns notified when spending reaches the limit', async () => {
     budget.upsertMonthlyBudget.mockResolvedValueOnce({ month: '2026-03-01', monthly_limit: '100.00', notified: false })
     budget.evaluateThresholdForMonth.mockResolvedValueOnce({ notified: true })
     await testApiHandler({
@@ -174,6 +175,35 @@ describe('GET /api/budget/summary', () => {
     })
   })
 
+  it('reports threshold_exceeded when spending reaches the monthly limit', async () => {
+    budget.buildBudgetSummary.mockResolvedValueOnce({
+      month: '2026-03-01',
+      monthly_limit: '500.00',
+      total_income: '3000.00',
+      total_expenses: '500.00',
+      remaining_budget: '0.00',
+      threshold_exceeded: true,
+      notified: true,
+    })
+    await testApiHandler({
+      appHandler: summaryHandler,
+      url: 'http://localhost/api/budget/summary?month=2026-03-01',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+          month: '2026-03-01',
+          monthly_limit: '500.00',
+          total_income: '3000.00',
+          total_expenses: '500.00',
+          remaining_budget: '0.00',
+          threshold_exceeded: true,
+          notified: true,
+        })
+      }
+    })
+  })
+
   it('returns 400 for an invalid month', async () => {
     budget.normalizeMonth.mockReturnValueOnce(null)
     await testApiHandler({
@@ -185,5 +215,67 @@ describe('GET /api/budget/summary', () => {
         expect((await res.json()).error).toBe('Valid month is required')
       }
     })
+  })
+})
+
+describe('budget helper threshold boundary', () => {
+  it('treats spending equal to the limit as threshold reached in the summary', async () => {
+    db.query
+      .mockResolvedValueOnce({
+        rows: [{ month: '2026-03-01', monthly_limit: '100.00', notified: false }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{ total_expenses: '100.00' }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{ total_income: '2500.00' }]
+      })
+
+    const summary = await actualBudget.buildBudgetSummary('uid', '2026-03-01')
+
+    expect(summary).toEqual({
+      month: '2026-03-01',
+      monthly_limit: '100.00',
+      total_income: '2500.00',
+      total_expenses: '100.00',
+      remaining_budget: '0.00',
+      threshold_exceeded: true,
+      notified: false,
+    })
+  })
+
+  it('triggers a budget alert when spending reaches the limit for the first time', async () => {
+    db.query
+      .mockResolvedValueOnce({
+        rows: [{ month: '2026-03-01', monthly_limit: '100.00', notified: false }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{ total_expenses: '100.00' }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{ total_income: '0.00' }]
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const result = await actualBudget.evaluateThresholdForMonth('uid', '2026-03-20')
+
+    expect(result).toEqual({
+      month: '2026-03-01',
+      monthly_limit: '100.00',
+      total_expenses: '100.00',
+      threshold_exceeded: true,
+      notified: true,
+      alertTriggered: true,
+      budget_alert: {
+        month: '2026-03-01',
+        monthly_limit: '100.00',
+        total_expenses: '100.00',
+        threshold_exceeded: true,
+      },
+    })
+    expect(db.query).toHaveBeenLastCalledWith(
+      expect.stringContaining('UPDATE public.budget_thresholds'),
+      ['uid', '2026-03-01', true]
+    )
   })
 })

--- a/nextjs/__tests__/expenses.test.js
+++ b/nextjs/__tests__/expenses.test.js
@@ -213,15 +213,17 @@ describe('POST /api/expenses/update', () => {
 })
 
 describe('POST /api/expenses/delete', () => {
-  it('204 - deleted', async () => {
+  it('200 - deleted with budget alert status', async () => {
     db.query
       .mockResolvedValueOnce({ rows: [{ date: '2026-03-01' }] })
       .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+    evaluateThresholdForMonth.mockResolvedValueOnce({ budget_alert: null, alertTriggered: false })
     await testApiHandler({
       appHandler: deleteHandler,
       async test({ fetch }) {
         const res = await fetch(post({ expense_id: 1 }))
-        expect(res.status).toBe(204)
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ id: 1, budget_alert: null })
       }
     })
     expect(evaluateThresholdForMonth).toHaveBeenCalledWith('uid', '2026-03-01')

--- a/nextjs/src/app/api/budget/route.js
+++ b/nextjs/src/app/api/budget/route.js
@@ -40,6 +40,7 @@ export async function POST(request) {
       month: savedBudget.month,
       monthly_limit: savedBudget.monthly_limit,
       notified: updatedBudget?.notified ?? false,
+      budget_alert: updatedBudget?.budget_alert ?? null,
     })
   } catch {
     return NextResponse.json({ error: 'Failed to save budget' }, { status: 500 })

--- a/nextjs/src/app/api/expenses/delete/route.js
+++ b/nextjs/src/app/api/expenses/delete/route.js
@@ -24,8 +24,8 @@ export async function POST(request) {
       [expense_id, user.id]
     )
     if (!rows.length) return NextResponse.json({ error: 'Expense not found' }, { status: 404 })
-    await evaluateThresholdForMonth(user.id, existingResult.rows[0].date)
-    return new Response(null, { status: 204 })
+    const threshold = await evaluateThresholdForMonth(user.id, existingResult.rows[0].date)
+    return NextResponse.json({ id: rows[0].id, budget_alert: threshold?.budget_alert ?? null })
   } catch {
     return NextResponse.json({ error: 'Failed to delete expense' }, { status: 500 })
   }

--- a/nextjs/src/lib/budget.js
+++ b/nextjs/src/lib/budget.js
@@ -93,7 +93,7 @@ export async function buildBudgetSummary(userId, month) {
 
   const totalExpenses = Number(totals.total_expenses)
   const monthlyLimit = budget?.monthly_limit == null ? null : String(budget.monthly_limit)
-  const thresholdExceeded = monthlyLimit == null ? false : totalExpenses > Number(monthlyLimit)
+  const thresholdExceeded = monthlyLimit == null ? false : totalExpenses >= Number(monthlyLimit)
 
   return {
     month,
@@ -116,7 +116,7 @@ export async function evaluateThresholdForMonth(userId, rawMonth) {
   const totals = await getMonthlyTotals(userId, month)
   const totalExpenses = Number(totals.total_expenses)
   const monthlyLimit = String(budget.monthly_limit)
-  const thresholdExceeded = totalExpenses > Number(monthlyLimit)
+  const thresholdExceeded = totalExpenses >= Number(monthlyLimit)
   const alertTriggered = thresholdExceeded && !budget.notified
 
   if (budget.notified !== thresholdExceeded) {

--- a/nextjs/src/lib/budget.js
+++ b/nextjs/src/lib/budget.js
@@ -3,6 +3,13 @@ import db from './db'
 const MONTH_PATTERN = /^\d{4}-\d{2}(-\d{2})?$/
 
 function toMonthStart(value) {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null
+    value = `${value.getUTCFullYear()}-${String(value.getUTCMonth() + 1).padStart(2, '0')}-${String(value.getUTCDate()).padStart(2, '0')}`
+  }
+  if (typeof value === 'string' && value.includes('T')) {
+    value = value.slice(0, 10)
+  }
   if (typeof value !== 'string' || !MONTH_PATTERN.test(value)) return null
 
   const [yearPart, monthPart, dayPart = '01'] = value.split('-')
@@ -53,7 +60,12 @@ export async function upsertMonthlyBudget(userId, month, monthlyLimit) {
     `INSERT INTO public.budget_thresholds (user_id, month, monthly_limit)
      VALUES ($1, $2, $3)
      ON CONFLICT (user_id, month)
-     DO UPDATE SET monthly_limit = EXCLUDED.monthly_limit
+     DO UPDATE SET
+       monthly_limit = EXCLUDED.monthly_limit,
+       notified = CASE
+         WHEN budget_thresholds.monthly_limit IS DISTINCT FROM EXCLUDED.monthly_limit THEN false
+         ELSE budget_thresholds.notified
+       END
      RETURNING month, monthly_limit, notified`,
     [userId, month, monthlyLimit]
   )
@@ -66,13 +78,13 @@ export async function getMonthlyTotals(userId, month) {
 
   const [expenseResult, incomeResult] = await Promise.all([
     db.query(
-      `SELECT COALESCE(SUM(amount), 0)::TEXT AS total_expenses
+      `SELECT COALESCE(SUM(amount), 0.00)::TEXT AS total_expenses
        FROM public.expenses
        WHERE user_id = $1 AND date >= $2 AND date < $3`,
       [userId, month, endMonth]
     ),
     db.query(
-      `SELECT COALESCE(SUM(amount), 0)::TEXT AS total_income
+      `SELECT COALESCE(SUM(amount), 0.00)::TEXT AS total_income
        FROM public.income
        WHERE user_id = $1 AND month = $2`,
       [userId, month]


### PR DESCRIPTION
## Description
This PR handles the release demo reliability lock before frontend work starts.

Changes included:
- updated budget threshold logic so reaching the monthly limit counts as threshold reached
- added focused Jest coverage for the equality boundary
- add backend logic to trigger an alert when budget threshold is surpassed on any event modifying or adding expense or budget data.
- fixed README setup/run/build instructions and documented the actual env vars used by the current code

## Related User Story / Issue
Fixes #27 

## Type of Change
- [x] Bug fix
- [x] Documentation
- [ ] New feature
- [ ] Backend / API change
- [ ] UI change
- [ ] Database change
- [ ] Refactor

## How Has This Been Tested?
- [x] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes
Verified by:
- running `npm test` in `nextjs/` successfully
- running `npm run build` in `nextjs/` with `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `DATABASE_URL` set successfully

## UI Changes (if applicable)
- [x] No UI changes
- [ ] UI updated (add screenshots if needed)

## Screenshots (if UI changed)

| Before | After |
| :--- | :--- |
| Image | Image |

## Notes for Reviewers
This PR is intentionally narrow and only covers demo reliability before frontend work begins.

Files changed:
- `nextjs/src/lib/budget.js`
- `nextjs/src/app/api/budget/route.js`
- `nextjs/src/app/api/expenses/delete/route.js`
- `nextjs/__tests__/budget.test.js`
- `nextjs/__tests__/expense.test.js`
- `README.md`

## Checklist
- [x] Linked to a user story or issue
- [X] Code builds / tests pass in CI
- [x] Ready for review