### PR TITLE
fix: remove misleading recurring and subscription UI (issue-55)

### DIFF
--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -10,7 +10,6 @@ import {
   demoBudgetSummary,
   demoCategoryBudgets,
   demoIncomeSources,
-  demoRecurringCharges,
 } from '@/lib/demoData'
 import { getCategoryVisual, getEntryVisual } from '@/lib/financeVisuals'
 import {
@@ -460,10 +459,6 @@ export default function InsightsView() {
     patternRotation: index % 2 === 0 ? 34 : -34,
   }))
   const liveMessage = getCombinedMessage(liveState.summaryMessage, liveState.listMessage)
-  const subscriptions = isSampleMode ? demoRecurringCharges : []
-  const subscriptionsCopy = isSampleMode
-    ? 'Bills coming up for the selected month.'
-    : 'Recurring bills will appear here when available for the selected month.'
   const centerLabel = viewMode === 'expenses' ? 'Spent this month' : 'Income this month'
   const centerLabelWords = centerLabel.split(' ')
   const budgetStatusValue = budgetLimit == null
@@ -713,33 +708,6 @@ export default function InsightsView() {
                 <span>{topExpensesEmptyCopy}</span>
               </div>
             )}
-          </article>
-
-          <article className="insight-card insight-pocket insight-card--subscriptions">
-            <div className="insight-card__header">
-              <div>
-                <span className="insight-pocket__eyebrow">Coming up</span>
-                <h2 className="insight-card__title">Upcoming subscriptions</h2>
-                <p className="insight-card__copy">{subscriptionsCopy}</p>
-              </div>
-            </div>
-
-            <div className="insight-pocket__list">
-              {subscriptions.length ? subscriptions.map((charge) => (
-                <div className="insight-pocket__row" key={charge.id}>
-                  <div>
-                    <strong>{charge.title}</strong>
-                    <span>Due {charge.dueLabel}</span>
-                  </div>
-                  <div className="entry-amount entry-amount--expense">-{formatCurrency(charge.amount)}</div>
-                </div>
-              )) : (
-                <div className="blank-state blank-state--compact">
-                  <strong>No subscriptions yet</strong>
-                  <span>Recurring bills will show here once they are available for the selected month.</span>
-                </div>
-              )}
-            </div>
           </article>
         </div>
       </div>

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -19,12 +19,6 @@ const ENTRY_CATEGORY_OPTIONS = {
   income: ['Income', 'Transfer', 'Freelance', 'Refund', 'Gift'],
 }
 
-const REPEATING_OPTIONS = [
-  { value: 'off', label: 'Off' },
-  { value: 'weekly', label: 'Weekly' },
-  { value: 'monthly', label: 'Monthly' },
-]
-
 const EXTRA_SAMPLE_ACTIVITY = [
   {
     id: 'demo-exp-9',
@@ -163,7 +157,6 @@ function createEntryDraft() {
     counterparty: '',
     category: ENTRY_CATEGORY_OPTIONS.expense[0],
     occurredOn: getTodayInputValue(),
-    repeating: 'off',
     note: '',
   }
 }
@@ -174,7 +167,6 @@ function createEditDraft(entry) {
     amount: String(entry.amount),
     category: entry.chip || (entry.kind === 'income' ? ENTRY_CATEGORY_OPTIONS.income[0] : ENTRY_CATEGORY_OPTIONS.expense[0]),
     occurredOn: entry.occurredOn || getTodayInputValue(),
-    repeating: 'off',
     note: '',
   }
   if (entry.kind === 'expense') {
@@ -859,22 +851,6 @@ export default function TransactionsView() {
                     value={entryDraft.occurredOn}
                   />
                 </label>
-              </div>
-
-              <div className="entry-sheet__field">
-                <span>Repeating</span>
-                <div className="segment-control segment-control--strong entry-sheet__repeat" role="group" aria-label="Repeating cadence">
-                  {REPEATING_OPTIONS.map((option) => (
-                    <button
-                      className={`segment-control__button${entryDraft.repeating === option.value ? ' segment-control__button--active' : ''}`}
-                      key={option.value}
-                      onClick={() => updateDraft('repeating', option.value)}
-                      type="button"
-                    >
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
               </div>
 
               <label className="entry-sheet__field">


### PR DESCRIPTION
## Description
Removes the misleading "Upcoming subscriptions" card and all related recurring charge UI from the Insights screen. The live app does not support recurring or subscription tracking, so these elements were creating a false impression of functionality that doesn't exist.

## Related User Story / Issue
Closes #55

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [ ] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes
- Navigated to the Insights screen and confirmed the "Upcoming subscriptions" card no longer appears
- Verified the rest of the Insights screen (donut chart, budget summary, top expenses) renders correctly and is unaffected
- Tested in both sample mode and live mode

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Screenshots (if UI changed)
| Before | After |
| :--- | :--- |
| "Upcoming subscriptions" card visible at the bottom of Insights | Card removed, Insights screen ends cleanly with Top Expenses |

## Notes for Reviewers
Also removed the `demoRecurringCharges` import and the `subscriptions` / `subscriptionsCopy` variables from `insights-view.js` since they were only used by the removed card. Two files were changed: insights-view.js (removed subscriptions card and related state) and transactions-view.js (removed Repeating cadence control, REPEATING_OPTIONS constant, and repeating draft field).

## Checklist
- [x] Linked to a user story or issue
- [ ] Code builds / tests pass in CI
- [x] Ready for review