### PR TITLE
Polish dashboard and insights hierarchy

### DIFF
--- a/nextjs/__tests__/budget-health.test.js
+++ b/nextjs/__tests__/budget-health.test.js
@@ -1,5 +1,6 @@
 const {
   BUDGET_NEAR_LIMIT_RATIO,
+  BUDGET_WATCH_RATIO,
   buildBudgetPressureHighlight,
   buildCategoryBudgetHealth,
   buildFinancialHealth,
@@ -251,6 +252,20 @@ describe('buildCategoryBudgetHealth', () => {
       label: 'Near limit',
       tone: 'warning',
       remainingAmount: 20,
+    }))
+  })
+
+  it('returns watch between watch ratio and near-limit', () => {
+    expect(BUDGET_WATCH_RATIO).toBe(0.6)
+    expect(buildCategoryBudgetHealth({
+      monthlyLimit: '100.00',
+      spent: '65.00',
+      actualsAvailable: true,
+    })).toEqual(expect.objectContaining({
+      key: 'watch',
+      label: 'Watch',
+      tone: 'caution',
+      remainingAmount: 35,
     }))
   })
 

--- a/nextjs/__tests__/frontend/allocationBar.unit.test.js
+++ b/nextjs/__tests__/frontend/allocationBar.unit.test.js
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+
+const React = require('react')
+const { render, screen, cleanup } = require('@testing-library/react')
+const { default: AllocationBar } = require('@/components/ui/AllocationBar')
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('AllocationBar', () => {
+  it('renders a progressbar with the rounded progress value', () => {
+    render(React.createElement(AllocationBar, {
+      progressPercentage: 42.7,
+      tone: 'positive',
+      ariaLabel: 'Monthly spend progress',
+    }))
+
+    const bar = screen.getByRole('progressbar', { name: 'Monthly spend progress' })
+    expect(bar.getAttribute('aria-valuenow')).toBe('43')
+    expect(bar.className).toContain('allocation-bar--positive')
+  })
+
+  it('clamps progress values above 100 to 100', () => {
+    render(React.createElement(AllocationBar, {
+      progressPercentage: 250,
+      tone: 'danger',
+      isOverBudget: true,
+    }))
+
+    const bar = screen.getByRole('progressbar')
+    expect(bar.getAttribute('aria-valuenow')).toBe('100')
+    expect(bar.className).toContain('allocation-bar--over')
+  })
+
+  it('places a day-of-month marker when activeDay and monthLength are provided', () => {
+    render(React.createElement(AllocationBar, {
+      progressPercentage: 30,
+      monthLength: 30,
+      activeDay: 15,
+      monthMarkerLabel: 'Day 15 of 30',
+    }))
+
+    const marker = screen.getByTestId('allocation-bar-marker')
+    expect(marker.getAttribute('style')).toContain('50%')
+    expect(marker.getAttribute('title')).toBe('Day 15 of 30')
+  })
+
+  it('hides the marker when showMarker is false', () => {
+    render(React.createElement(AllocationBar, {
+      progressPercentage: 30,
+      monthLength: 30,
+      activeDay: 15,
+      showMarker: false,
+    }))
+
+    expect(screen.queryByTestId('allocation-bar-marker')).toBeNull()
+  })
+
+  it('hides the marker when monthLength or activeDay is missing', () => {
+    const { rerender } = render(React.createElement(AllocationBar, {
+      progressPercentage: 30,
+      monthLength: 0,
+      activeDay: 15,
+    }))
+    expect(screen.queryByTestId('allocation-bar-marker')).toBeNull()
+
+    rerender(React.createElement(AllocationBar, {
+      progressPercentage: 30,
+      monthLength: 30,
+      activeDay: 0,
+    }))
+    expect(screen.queryByTestId('allocation-bar-marker')).toBeNull()
+  })
+
+  it('sets aria-valuetext when provided', () => {
+    render(React.createElement(AllocationBar, {
+      progressPercentage: 80,
+      tone: 'warning',
+      ariaLabel: 'Spent of budget',
+      ariaValueText: '80% used, $200 left',
+    }))
+
+    const bar = screen.getByRole('progressbar', { name: 'Spent of budget' })
+    expect(bar.getAttribute('aria-valuetext')).toBe('80% used, $200 left')
+  })
+})

--- a/nextjs/__tests__/frontend/budgetHudMetrics.unit.test.js
+++ b/nextjs/__tests__/frontend/budgetHudMetrics.unit.test.js
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+
+const React = require('react')
+const { render, screen, cleanup } = require('@testing-library/react')
+const { default: BudgetHudMetrics } = require('@/components/ui/BudgetHudMetrics')
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('BudgetHudMetrics', () => {
+  it('renders nothing when no metrics are provided', () => {
+    const { container } = render(React.createElement(BudgetHudMetrics, { metrics: [] }))
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders each metric with its label, value, and hint in order', () => {
+    const metrics = [
+      { label: 'Spent', value: '$450', hint: 'Current month' },
+      { label: 'Days left', value: '11', hint: 'Including today' },
+      { label: 'Daily allowance', value: '$50', hint: 'Left per day' },
+      { label: 'Net this month', value: '$750', hint: 'Income minus spend' },
+    ]
+
+    render(React.createElement(BudgetHudMetrics, { metrics }))
+
+    const items = screen.getAllByRole('term')
+    expect(items.map((node) => node.textContent)).toEqual(['Spent', 'Days left', 'Daily allowance', 'Net this month'])
+    expect(screen.getByText('$450')).toBeTruthy()
+    expect(screen.getByText('Current month')).toBeTruthy()
+    expect(screen.getByText('Income minus spend')).toBeTruthy()
+  })
+
+  it('omits the hint row when hint is not provided', () => {
+    render(React.createElement(BudgetHudMetrics, {
+      metrics: [{ label: 'Spent', value: '--' }],
+    }))
+
+    expect(screen.getByText('Spent')).toBeTruthy()
+    expect(screen.getByText('--')).toBeTruthy()
+    expect(document.querySelector('.budget-hud-metrics__hint')).toBeNull()
+  })
+})

--- a/nextjs/__tests__/frontend/cashFlowSnapshot.unit.test.js
+++ b/nextjs/__tests__/frontend/cashFlowSnapshot.unit.test.js
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }) => require('react').createElement('a', { href, ...props }, children),
+}))
+jest.mock('@/lib/financeUtils', () => ({
+  formatCurrency: jest.fn((value) => {
+    const amount = Number(value)
+    if (!Number.isFinite(amount)) return '--'
+    const abs = Math.abs(amount)
+    const sign = amount < 0 ? '-' : ''
+    return `${sign}$${abs.toFixed(2)}`
+  }),
+  formatPercentage: jest.fn((value) => `${Math.round(Number(value) || 0)}%`),
+}))
+
+const React = require('react')
+const { render, screen, fireEvent, cleanup } = require('@testing-library/react')
+const { default: CashFlowSnapshot } = require('@/components/ui/CashFlowSnapshot')
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CashFlowSnapshot', () => {
+  it('renders income, expense, and net for a positive month', () => {
+    render(React.createElement(CashFlowSnapshot, {
+      income: 2400,
+      expenses: 820,
+      trend: [],
+      monthLabel: 'March 2026',
+    }))
+
+    expect(screen.getByText('March 2026')).toBeTruthy()
+    expect(screen.getByText('$2400.00')).toBeTruthy()
+    expect(screen.getByText('$820.00')).toBeTruthy()
+    expect(screen.getByText('+$1580.00')).toBeTruthy()
+    expect(document.querySelector('.cashflow-snapshot--positive')).toBeTruthy()
+  })
+
+  it('shows a negative net tone and no plus sign when expenses exceed income', () => {
+    render(React.createElement(CashFlowSnapshot, {
+      income: 400,
+      expenses: 600,
+    }))
+
+    expect(document.querySelector('.cashflow-snapshot--danger')).toBeTruthy()
+    expect(screen.getByText('-$200.00')).toBeTruthy()
+  })
+
+  it('renders an empty placeholder when there is no month data', () => {
+    render(React.createElement(CashFlowSnapshot, {
+      income: 0,
+      expenses: 0,
+    }))
+
+    expect(screen.getByText(/income vs expense shape will appear/i)).toBeTruthy()
+  })
+
+  it('renders one focusable trend button per month and shows the focused readout', () => {
+    render(React.createElement(CashFlowSnapshot, {
+      income: 3000,
+      expenses: 1500,
+      trend: [
+        { month: '2026-01-01', label: 'Jan', netAmount: 500 },
+        { month: '2026-02-01', label: 'Feb', netAmount: -200 },
+        { month: '2026-03-01', label: 'Mar', netAmount: 1500 },
+      ],
+    }))
+
+    const buttons = document.querySelectorAll('.cashflow-snapshot__trend-col')
+    expect(buttons.length).toBe(3)
+    expect(screen.getByText(/Mar latest/)).toBeTruthy()
+
+    fireEvent.focus(buttons[0])
+    expect(screen.getByText('Jan selected')).toBeTruthy()
+  })
+
+  it('shows "--" for savings rate when there is no income', () => {
+    render(React.createElement(CashFlowSnapshot, {
+      income: 0,
+      expenses: 300,
+    }))
+
+    expect(screen.getByText('--')).toBeTruthy()
+  })
+
+  it('renders a "View more" link to Insights when viewMoreHref is provided', () => {
+    render(React.createElement(CashFlowSnapshot, {
+      income: 1000,
+      expenses: 400,
+      viewMoreHref: '/insights',
+    }))
+
+    const link = screen.getByRole('link', { name: /View more/ })
+    expect(link.getAttribute('href')).toBe('/insights')
+  })
+})

--- a/nextjs/__tests__/frontend/categoryProgressRow.unit.test.js
+++ b/nextjs/__tests__/frontend/categoryProgressRow.unit.test.js
@@ -1,0 +1,159 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/lib/financeUtils', () => ({
+  formatCurrency: jest.fn((value) => {
+    const amount = Number(value)
+    if (!Number.isFinite(amount)) return '--'
+    return `$${amount.toFixed(2)}`
+  }),
+}))
+
+const React = require('react')
+const { render, screen, cleanup } = require('@testing-library/react')
+const { default: CategoryProgressRow } = require('@/components/ui/CategoryProgressRow')
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CategoryProgressRow', () => {
+  it('renders name, icon, and spent/budget text when a budget is provided', () => {
+    render(React.createElement(CategoryProgressRow, {
+      name: 'Groceries',
+      symbol: 'G',
+      amount: 120,
+      monthlyLimit: 300,
+      progressPercentage: 40,
+      remainingAmount: 180,
+      tone: 'positive',
+      statusLabel: 'On track',
+    }))
+
+    expect(screen.getByText('Groceries')).toBeTruthy()
+    expect(screen.getByText('G')).toBeTruthy()
+    expect(screen.getByText('$120.00 / $300.00')).toBeTruthy()
+    const bar = screen.getByRole('progressbar', { name: /Groceries budget progress/ })
+    expect(bar.getAttribute('aria-valuenow')).toBe('40')
+  })
+
+  it('hides the status chip on positive tones but shows it when tone is warning or danger', () => {
+    const { rerender } = render(React.createElement(CategoryProgressRow, {
+      name: 'Dining',
+      symbol: 'D',
+      amount: 240,
+      monthlyLimit: 300,
+      progressPercentage: 80,
+      remainingAmount: 60,
+      tone: 'positive',
+      statusLabel: 'On track',
+    }))
+
+    expect(screen.queryByText('On track')).toBeNull()
+
+    rerender(React.createElement(CategoryProgressRow, {
+      name: 'Dining',
+      symbol: 'D',
+      amount: 260,
+      monthlyLimit: 300,
+      progressPercentage: 87,
+      remainingAmount: 40,
+      tone: 'warning',
+      statusLabel: 'Near limit',
+    }))
+
+    expect(screen.getByText('Near limit')).toBeTruthy()
+
+    rerender(React.createElement(CategoryProgressRow, {
+      name: 'Dining',
+      symbol: 'D',
+      amount: 400,
+      monthlyLimit: 300,
+      progressPercentage: 100,
+      remainingAmount: -100,
+      tone: 'danger',
+      statusLabel: 'Over budget',
+    }))
+
+    expect(screen.getByText('Over budget')).toBeTruthy()
+  })
+
+  it('applies the over-budget class when remainingAmount is negative', () => {
+    const { container } = render(React.createElement(CategoryProgressRow, {
+      name: 'Fun',
+      symbol: 'F',
+      amount: 420,
+      monthlyLimit: 300,
+      progressPercentage: 100,
+      remainingAmount: -120,
+      tone: 'danger',
+      statusLabel: 'Over budget',
+    }))
+
+    expect(container.querySelector('.category-progress-row--over')).toBeTruthy()
+  })
+
+  it('falls back to spent-only text and share label when no budget is set', () => {
+    render(React.createElement(CategoryProgressRow, {
+      name: 'Transfers',
+      symbol: 'T',
+      amount: 50,
+      monthlyLimit: null,
+      progressPercentage: 35,
+      tone: 'neutral',
+      fallbackShareText: '35% of spend',
+    }))
+
+    expect(screen.getByText('Transfers')).toBeTruthy()
+    expect(screen.getByText('$50.00')).toBeTruthy()
+    expect(screen.getByText('35% of spend')).toBeTruthy()
+    const bar = screen.getByRole('progressbar', { name: /Transfers share of spend/ })
+    expect(bar.getAttribute('aria-valuenow')).toBe('35')
+  })
+
+  it('clamps progressPercentage to the 0-100 range', () => {
+    render(React.createElement(CategoryProgressRow, {
+      name: 'Shopping',
+      symbol: 'S',
+      amount: 999,
+      monthlyLimit: 500,
+      progressPercentage: 250,
+      remainingAmount: -499,
+      tone: 'danger',
+    }))
+
+    const bar = screen.getByRole('progressbar', { name: /Shopping budget progress/ })
+    expect(bar.getAttribute('aria-valuenow')).toBe('100')
+  })
+
+  it('forces the chip to render when showStatusChip is always', () => {
+    render(React.createElement(CategoryProgressRow, {
+      name: 'Groceries',
+      symbol: 'G',
+      amount: 100,
+      monthlyLimit: 400,
+      progressPercentage: 25,
+      remainingAmount: 300,
+      tone: 'positive',
+      statusLabel: 'On track',
+      showStatusChip: 'always',
+    }))
+
+    expect(screen.getByText('On track')).toBeTruthy()
+  })
+
+  it('never renders the chip when showStatusChip is never', () => {
+    render(React.createElement(CategoryProgressRow, {
+      name: 'Groceries',
+      symbol: 'G',
+      amount: 400,
+      monthlyLimit: 300,
+      progressPercentage: 100,
+      remainingAmount: -100,
+      tone: 'danger',
+      statusLabel: 'Over budget',
+      showStatusChip: 'never',
+    }))
+
+    expect(screen.queryByText('Over budget')).toBeNull()
+  })
+})

--- a/nextjs/__tests__/frontend/categoryTransactionsModal.unit.test.js
+++ b/nextjs/__tests__/frontend/categoryTransactionsModal.unit.test.js
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/lib/financeUtils', () => ({
+  formatCurrency: jest.fn((value) => {
+    const amount = Number(value)
+    if (!Number.isFinite(amount)) return '--'
+    return `$${amount.toFixed(2)}`
+  }),
+  formatShortDate: jest.fn((value) => `Short ${value}`),
+}))
+
+const React = require('react')
+const { render, screen, fireEvent, cleanup } = require('@testing-library/react')
+const { default: CategoryTransactionsModal } = require('@/components/ui/CategoryTransactionsModal')
+
+const SAMPLE_CATEGORY = {
+  id: 'shopping',
+  name: 'Shopping',
+  color: '#c9869e',
+  soft: 'rgba(201,134,158,0.18)',
+  symbol: 'S',
+}
+
+const CURRENT_DETAILS = [
+  { id: 'tx-1', amount: 50, title: 'Target', categoryName: 'Shopping', occurredOn: '2026-03-12', color: '#c9869e', soft: 'rgba(201,134,158,0.18)', symbol: 'S' },
+  { id: 'tx-2', amount: 130, title: 'Amazon', categoryName: 'Shopping', occurredOn: '2026-03-22', color: '#c9869e', soft: 'rgba(201,134,158,0.18)', symbol: 'S' },
+  { id: 'tx-3', amount: 20, title: 'Whole Foods', categoryName: 'Groceries', occurredOn: '2026-03-15', color: '#6faa80', soft: 'rgba(111,170,128,0.18)', symbol: 'G' },
+]
+
+const PREVIOUS_DETAILS = [
+  { id: 'prev-1', amount: 80, title: 'Amazon (Feb)', categoryName: 'Shopping', occurredOn: '2026-02-10', color: '#c9869e', soft: 'rgba(201,134,158,0.18)', symbol: 'S' },
+]
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('CategoryTransactionsModal', () => {
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(React.createElement(CategoryTransactionsModal, {
+      isOpen: false,
+      onClose: jest.fn(),
+      category: SAMPLE_CATEGORY,
+      currentMonthDetails: CURRENT_DETAILS,
+    }))
+    expect(container.querySelector('.category-modal')).toBeNull()
+  })
+
+  it('renders only this month transactions sorted largest first when previousMonthDetails is null', () => {
+    render(React.createElement(CategoryTransactionsModal, {
+      isOpen: true,
+      onClose: jest.fn(),
+      category: SAMPLE_CATEGORY,
+      currentMonthDetails: CURRENT_DETAILS,
+      currentMonthLabel: 'March 2026',
+    }))
+
+    const titles = Array.from(document.querySelectorAll('.category-modal__row strong'))
+      .filter((node) => node.classList.contains('category-modal__row-amount') === false)
+      .map((node) => node.textContent)
+    expect(titles[0]).toBe('Amazon')
+    expect(titles[1]).toBe('Target')
+    expect(screen.queryByText('Whole Foods')).toBeNull()
+    expect(screen.getAllByText('March 2026').length).toBeGreaterThan(0)
+  })
+
+  it('renders compare mode with both columns and a change tone when previousMonthDetails is provided', () => {
+    render(React.createElement(CategoryTransactionsModal, {
+      isOpen: true,
+      onClose: jest.fn(),
+      category: SAMPLE_CATEGORY,
+      currentMonthDetails: CURRENT_DETAILS,
+      previousMonthDetails: PREVIOUS_DETAILS,
+      currentMonthLabel: 'March 2026',
+      previousMonthLabel: 'February 2026',
+    }))
+
+    expect(screen.getAllByText('March 2026').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('February 2026').length).toBeGreaterThan(0)
+    expect(screen.getByText('Amazon (Feb)')).toBeTruthy()
+    expect(document.querySelector('.category-modal__totals-delta--danger')).toBeTruthy()
+  })
+
+  it('invokes onClose when backdrop or close button is clicked', () => {
+    const onClose = jest.fn()
+    render(React.createElement(CategoryTransactionsModal, {
+      isOpen: true,
+      onClose,
+      category: SAMPLE_CATEGORY,
+      currentMonthDetails: CURRENT_DETAILS,
+      currentMonthLabel: 'March 2026',
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /Close Shopping transactions/ }))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/nextjs/__tests__/frontend/categoryTransactionsModal.unit.test.js
+++ b/nextjs/__tests__/frontend/categoryTransactionsModal.unit.test.js
@@ -97,4 +97,17 @@ describe('CategoryTransactionsModal', () => {
     fireEvent.click(screen.getByRole('button', { name: /Close Shopping transactions/ }))
     expect(onClose).toHaveBeenCalledTimes(2)
   })
+
+  it('invokes onClose when Escape is pressed while the dialog is open', () => {
+    const onClose = jest.fn()
+    render(React.createElement(CategoryTransactionsModal, {
+      isOpen: true,
+      onClose,
+      category: SAMPLE_CATEGORY,
+      currentMonthDetails: CURRENT_DETAILS,
+    }))
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
 })

--- a/nextjs/__tests__/frontend/dashboard.test.js
+++ b/nextjs/__tests__/frontend/dashboard.test.js
@@ -73,6 +73,13 @@ jest.mock('@/lib/demoData', () => ({
     { id: 'food', name: 'Food', budget: 350, spent: 320 },
     { id: 'fun', name: 'Fun', budget: 250, spent: 180 },
   ],
+  demoInsightsSnapshot: {
+    dailySpend: {
+      details: [
+        { id: 'x1', amount: 10, title: 'Test', categoryName: 'Food', occurredOn: '2026-03-12', color: '#123', soft: '#abc', symbol: 'F' },
+      ],
+    },
+  },
 }))
 jest.mock('@/lib/financeVisuals', () => ({
   getCategoryVisual: jest.fn((value) => ({
@@ -90,9 +97,13 @@ jest.mock('@/lib/financeVisuals', () => ({
 }))
 jest.mock('@/lib/financeUtils', () => ({
   buildActivityFeed: jest.fn(),
+  buildDailySpendDetailsFromExpenses: jest.fn(() => []),
   buildMonthlySpendTrend: jest.fn(),
+  buildRecentCashFlow: jest.fn(() => []),
+  buildTrendChartAxes: jest.fn(() => ({ paceLine: null, budgetLineY: null, axisLabels: null, plotLeft: 18, plotRight: 294 })),
   formatCurrency: jest.fn((value) => `$${value}`),
   formatMonthPeriod: jest.fn((value) => value),
+  formatPercentage: jest.fn((value) => `${Math.round(Number(value) || 0)}%`),
   formatShortDate: jest.fn((value) => value),
   getCurrentMonthStart: jest.fn((date = new Date()) => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-01`),
   isInMonth: jest.fn(),
@@ -265,10 +276,10 @@ describe('getCategoryCards', () => {
         category_id: 'cat-food',
         category_name: 'Food',
         category_icon: 'F',
-        monthly_limit: '80.00',
+        monthly_limit: '100.00',
         spent: '50.00',
-        remaining_budget: '30.00',
-        progress_percentage: 62.5,
+        remaining_budget: '50.00',
+        progress_percentage: 50,
       },
     ], [
       { id: 'e1', category_id: 'cat-other', category_name: 'Other', amount: '999.00' },
@@ -276,8 +287,8 @@ describe('getCategoryCards', () => {
       expect.objectContaining({
         name: 'Food',
         amount: 50,
-        progress: 62.5,
-        note: '$30 left',
+        progress: 50,
+        note: '$50 left',
         statusLabel: 'On track',
         statusTone: 'positive',
       }),
@@ -617,13 +628,13 @@ describe('getBudgetPressureHighlight', () => {
   it('returns a waiting message when neither budgets nor expenses are available', () => {
     expect(getBudgetPressureHighlight({
       category_statuses: [],
-    }, [])).toEqual({
+    }, [])).toEqual(expect.objectContaining({
       key: 'waiting',
       tone: 'neutral',
       label: 'Category pressure',
       title: 'Waiting on categories',
       detail: 'Current-month category pressure will show once expenses land.',
-    })
+    }))
   })
 })
 
@@ -652,7 +663,6 @@ describe('DashboardView', () => {
     expect(screen.getByText('$180 left')).toBeTruthy()
     expect(screen.getAllByText('Near limit').length).toBeGreaterThan(0)
     expect(screen.getByText('Positive cash flow')).toBeTruthy()
-    expect(screen.getByText('Top category pressure')).toBeTruthy()
     expect(screen.getAllByText('Food').length).toBeGreaterThan(0)
     expect(screen.getByText('Grocer')).toBeTruthy()
     expect(screen.getAllByText('Paycheck').length).toBeGreaterThan(0)
@@ -705,7 +715,6 @@ describe('DashboardView', () => {
     expect(screen.getAllByText('Near limit').length).toBeGreaterThan(0)
     expect(screen.getByText('$140 left')).toBeTruthy()
     expect(screen.getByText('Positive cash flow')).toBeTruthy()
-    expect(screen.getByText('Top category pressure')).toBeTruthy()
     expect(screen.getByText('Grocer')).toBeTruthy()
     expect(screen.getAllByText('Paycheck').length).toBeGreaterThan(0)
   })

--- a/nextjs/__tests__/frontend/financeUtils.unit.test.js
+++ b/nextjs/__tests__/frontend/financeUtils.unit.test.js
@@ -6,8 +6,12 @@ const {
   formatMonthPeriod,
   buildMonthlySpendTrend,
   buildActivityFeed,
+  buildDailySpendDetailsFromExpenses,
   groupActivityByDate,
   buildIncomeSourceBreakdown,
+  buildRecentCashFlow,
+  buildCumulativeDailyTotals,
+  buildTrendChartAxes,
 } = require('@/lib/financeUtils')
 
 describe('parseCalendarDate', () => {
@@ -109,6 +113,25 @@ describe('buildActivityFeed', () => {
   })
 })
 
+describe('buildDailySpendDetailsFromExpenses', () => {
+  it('maps expense API rows into modal detail entries grouped by day', () => {
+    const rows = [
+      { id: 'a', amount: '30.00', date: '2026-03-10', description: 'Lunch', category_name: 'Dining' },
+      { id: 'b', amount: '10.00', date: '2026-03-10', description: 'Snack', category_name: 'Dining' },
+    ]
+    const details = buildDailySpendDetailsFromExpenses(rows)
+    expect(details).toHaveLength(2)
+    expect(details[0].amount).toBe(30)
+    expect(details[0].occurredOn).toBe('2026-03-10')
+    expect(details[0].categoryName).toBeTruthy()
+    expect(details[1].amount).toBe(10)
+  })
+
+  it('skips rows without a parseable date', () => {
+    expect(buildDailySpendDetailsFromExpenses([{ id: 'x', amount: 5, date: null }])).toEqual([])
+  })
+})
+
 describe('groupActivityByDate', () => {
   it('groups entries sharing a day and sorts groups newest first', () => {
     const entries = [
@@ -134,5 +157,99 @@ describe('buildIncomeSourceBreakdown', () => {
     expect(result).toHaveLength(1)
     expect(result[0].name).toBe('Payroll')
     expect(result[0].amount).toBe(2500)
+  })
+})
+
+describe('buildRecentCashFlow', () => {
+  it('returns the last N months of income, expense, and net totals', () => {
+    const expenses = [
+      { id: 'e1', amount: '80', date: '2026-01-12' },
+      { id: 'e2', amount: '120', date: '2026-02-04' },
+      { id: 'e3', amount: '200', date: '2026-03-15' },
+      { id: 'e4', amount: '50', date: '2026-03-22' },
+    ]
+    const income = [
+      { id: 'i1', amount: '1000', date: '2026-01-05' },
+      { id: 'i2', amount: '1200', date: '2026-02-05' },
+      { id: 'i3', amount: '1500', date: '2026-03-02' },
+    ]
+    const series = buildRecentCashFlow(expenses, income, '2026-03-01', 3)
+    expect(series.map((item) => item.month)).toEqual(['2026-01-01', '2026-02-01', '2026-03-01'])
+    expect(series[0].incomeAmount).toBe(1000)
+    expect(series[0].expenseAmount).toBe(80)
+    expect(series[0].netAmount).toBe(920)
+    expect(series[2].expenseAmount).toBe(250)
+    expect(series[2].netAmount).toBe(1250)
+  })
+
+  it('returns an empty array when the month is invalid', () => {
+    expect(buildRecentCashFlow([], [], 'nope')).toEqual([])
+  })
+
+  it('returns zeroed months when there is no matching data', () => {
+    const series = buildRecentCashFlow([], [], '2026-03-01', 2)
+    expect(series).toHaveLength(2)
+    series.forEach((item) => {
+      expect(item.incomeAmount).toBe(0)
+      expect(item.expenseAmount).toBe(0)
+      expect(item.netAmount).toBe(0)
+    })
+  })
+})
+
+describe('buildCumulativeDailyTotals', () => {
+  it('produces one entry per day with running spend totals', () => {
+    const expenses = [
+      { id: 'e1', amount: '50', date: '2026-03-03' },
+      { id: 'e2', amount: '30', date: '2026-03-10' },
+      { id: 'e3', amount: '70', date: '2026-03-10' },
+    ]
+    const series = buildCumulativeDailyTotals(expenses, '2026-03-01')
+    expect(series).toHaveLength(31)
+    expect(series[2].amount).toBe(50)
+    expect(series[9].amount).toBe(150)
+    expect(series[30].amount).toBe(150)
+  })
+
+  it('returns an empty array for an invalid month', () => {
+    expect(buildCumulativeDailyTotals([], 'nope')).toEqual([])
+  })
+})
+
+describe('buildTrendChartAxes', () => {
+  it('returns a pace line, budget line y-coordinate, and axis labels when a budget exists', () => {
+    const axes = buildTrendChartAxes({
+      budget: 1000,
+      monthLength: 31,
+      activeDay: 15,
+      pointCount: 15,
+      width: 312,
+      height: 148,
+      inset: 18,
+    })
+
+    expect(axes.budgetLineY).toBe(18)
+    expect(axes.axisLabels).toHaveLength(2)
+    expect(axes.axisLabels[0]).toEqual({ y: 130, value: 0 })
+    expect(axes.axisLabels[1]).toEqual({ y: 18, value: 1000 })
+    expect(axes.paceLine).toMatchObject({ startX: 18, startY: 130 })
+    expect(axes.paceLine.endX).toBeGreaterThan(18)
+    expect(axes.paceLine.endY).toBeLessThan(130)
+    expect(axes.budgetLineLabel).toBe('$1,000.00')
+  })
+
+  it('omits pace line and axis labels when no budget is provided', () => {
+    const axes = buildTrendChartAxes({
+      budget: 0,
+      monthLength: 30,
+      activeDay: 10,
+      pointCount: 10,
+      width: 312,
+      height: 148,
+      inset: 18,
+    })
+    expect(axes.paceLine).toBeNull()
+    expect(axes.budgetLineY).toBeNull()
+    expect(axes.axisLabels).toBeNull()
   })
 })

--- a/nextjs/__tests__/frontend/financeUtils.unit.test.js
+++ b/nextjs/__tests__/frontend/financeUtils.unit.test.js
@@ -130,6 +130,17 @@ describe('buildDailySpendDetailsFromExpenses', () => {
   it('skips rows without a parseable date', () => {
     expect(buildDailySpendDetailsFromExpenses([{ id: 'x', amount: 5, date: null }])).toEqual([])
   })
+
+  it('assigns distinct fallback ids when the same day has multiple id-less rows with an identical fingerprint', () => {
+    const rows = [
+      { id: null, amount: '10.00', date: '2026-03-10', description: 'Snack', category_name: 'Dining' },
+      { id: null, amount: '10.00', date: '2026-03-10', description: 'Snack', category_name: 'Dining' },
+    ]
+    const details = buildDailySpendDetailsFromExpenses(rows)
+    const ids = details.map((entry) => entry.id)
+    expect(new Set(ids).size).toBe(2)
+    expect(ids.some((id) => /:2/.test(String(id)))).toBe(true)
+  })
 })
 
 describe('groupActivityByDate', () => {

--- a/nextjs/__tests__/frontend/financialHealthTile.unit.test.js
+++ b/nextjs/__tests__/frontend/financialHealthTile.unit.test.js
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/lib/financeUtils', () => ({
+  formatCurrency: jest.fn((value) => {
+    const amount = Number(value)
+    if (!Number.isFinite(amount)) return '--'
+    return `$${amount.toFixed(2)}`
+  }),
+}))
+
+const React = require('react')
+const { render, screen, cleanup } = require('@testing-library/react')
+const { default: FinancialHealthTile } = require('@/components/ui/FinancialHealthTile')
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('FinancialHealthTile', () => {
+  it('renders nothing when no health is provided', () => {
+    const { container } = render(React.createElement(FinancialHealthTile, { health: null }))
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the stacked bar, legend, and net value for a positive month', () => {
+    render(React.createElement(FinancialHealthTile, {
+      health: {
+        key: 'positive_cash_flow',
+        label: 'Positive cash flow',
+        tone: 'positive',
+        valueText: '$750 ahead',
+        detailText: 'Income exceeds expenses this month.',
+      },
+      income: 2400,
+      expenses: 820,
+    }))
+
+    expect(screen.getByText('Positive cash flow')).toBeTruthy()
+    expect(screen.getByText('$2400.00')).toBeTruthy()
+    expect(screen.getByText('$820.00')).toBeTruthy()
+    expect(screen.getByText('$750 ahead')).toBeTruthy()
+    expect(document.querySelector('.health-tile__segment--income')).toBeTruthy()
+    expect(document.querySelector('.health-tile__segment--expense')).toBeTruthy()
+  })
+
+  it('shows the detail-text placeholder when the month has no income or expenses yet', () => {
+    render(React.createElement(FinancialHealthTile, {
+      health: {
+        key: 'break_even',
+        label: 'Break even',
+        tone: 'neutral',
+        valueText: '$0.00',
+        detailText: 'Income matches expenses this month.',
+      },
+      income: 0,
+      expenses: 0,
+    }))
+
+    expect(screen.getByText('Income matches expenses this month.')).toBeTruthy()
+    expect(document.querySelector('.health-tile__segment--income')).toBeNull()
+  })
+
+  it('renders a placeholder when the health is loading or unavailable', () => {
+    render(React.createElement(FinancialHealthTile, {
+      health: {
+        key: 'unavailable',
+        label: 'Unavailable',
+        tone: 'neutral',
+        valueText: 'Health unavailable',
+        detailText: 'Financial health is unavailable until the live summary returns.',
+      },
+      income: 1000,
+      expenses: 500,
+    }))
+
+    expect(screen.getByText('Financial health is unavailable until the live summary returns.')).toBeTruthy()
+    expect(document.querySelector('.health-tile__segment--income')).toBeNull()
+  })
+})

--- a/nextjs/__tests__/frontend/insights-view.integration.test.js
+++ b/nextjs/__tests__/frontend/insights-view.integration.test.js
@@ -1,5 +1,9 @@
 /** @jest-environment jsdom */
 
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }) => require('react').createElement('a', { href, ...props }, children),
+}))
 jest.mock('next/navigation', () => ({ useRouter: jest.fn() }))
 jest.mock('@/components/providers', () => ({
   useAuth: jest.fn(),
@@ -137,12 +141,30 @@ describe('InsightsView (sample data)', () => {
     expect(screen.getAllByText('vs last month').length).toBeGreaterThan(0)
     expect(screen.getByText('Spend / active day')).toBeTruthy()
     expect(screen.getByRole('button', { name: /Open March 2026 month view/ })).toBeTruthy()
-    expect(screen.getByText('Top expenses')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Top expenses' })).toBeTruthy()
     expect(
       screen.getByLabelText('Mar cash flow details: income $3,229.00, expenses $1,011.36, net +$2,217.64')
     ).toBeTruthy()
-    expect(screen.getByText(/of category budget|of monthly spend|vs largest purchase/)).toBeTruthy()
-    expect(container.querySelector('.insights-v57__sparkline')).toBeTruthy()
     expect(container.querySelector('.insights-v57__cashflow-peak')).toBeTruthy()
+  })
+
+  it('renders the new Category detail section with CategoryProgressRow items and a pace-vs-last-month chart', () => {
+    const { container } = render(React.createElement(InsightsView))
+
+    expect(screen.getByRole('heading', { name: 'Category detail' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Pace vs last month' })).toBeTruthy()
+    expect(container.querySelector('.category-progress-list--insights')).toBeTruthy()
+    expect(container.querySelector('.pace-chart')).toBeTruthy()
+  })
+
+  it('shows a readable cash flow scale note in the card header', () => {
+    const { container } = render(React.createElement(InsightsView))
+    expect(container.querySelector('.insights-v57__cashflow-baseline-label')).toBeNull()
+  })
+
+  it('does not render the removed spend-pattern sparkline', () => {
+    const { container } = render(React.createElement(InsightsView))
+    expect(container.querySelector('.insights-v57__sparkline')).toBeNull()
+    expect(container.querySelector('.insights-v57__cashflow-summary')).toBeNull()
   })
 })

--- a/nextjs/__tests__/frontend/monthPacingChart.unit.test.js
+++ b/nextjs/__tests__/frontend/monthPacingChart.unit.test.js
@@ -1,0 +1,116 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/lib/financeUtils', () => {
+  const actual = jest.requireActual('@/lib/financeUtils')
+  return {
+    ...actual,
+    formatCurrency: jest.fn((value) => {
+      const amount = Number(value)
+      if (!Number.isFinite(amount)) return '--'
+      return `$${amount.toFixed(2)}`
+    }),
+  }
+})
+
+const React = require('react')
+const { render, screen, fireEvent, cleanup } = require('@testing-library/react')
+const { default: MonthPacingChart } = require('@/components/ui/MonthPacingChart')
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MonthPacingChart', () => {
+  it('renders the empty-state node when no trend points are provided', () => {
+    const emptyState = React.createElement('div', { 'data-testid': 'empty-state' }, 'no data')
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [],
+      budget: 1000,
+      monthLength: 30,
+      activeDay: 5,
+      emptyState,
+    }))
+    expect(screen.getByTestId('empty-state')).toBeTruthy()
+  })
+
+  it('renders x-axis labels and the actual/pace/budget legend by default', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [100, 200, 350],
+      budget: 1000,
+      monthLength: 30,
+      activeDay: 3,
+    }))
+    expect(screen.getByText('Day 1')).toBeTruthy()
+    expect(screen.getByText('Day 30')).toBeTruthy()
+    expect(screen.getByText('Actual')).toBeTruthy()
+    expect(screen.getByText('Pace')).toBeTruthy()
+    expect(screen.getByText('Budget')).toBeTruthy()
+  })
+
+  it('shifts the focused point with arrow keys and updates the callout', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [50, 100, 150, 200, 300],
+      budget: 1200,
+      monthLength: 30,
+      activeDay: 5,
+    }))
+
+    const svg = screen.getByRole('img')
+    expect(screen.getAllByText('Day 5').length).toBeGreaterThan(0)
+
+    fireEvent.keyDown(svg, { key: 'ArrowLeft' })
+    expect(screen.getAllByText('Day 4').length).toBeGreaterThan(0)
+
+    fireEvent.keyDown(svg, { key: 'Home' })
+    expect(screen.getAllByText('Day 1').length).toBeGreaterThan(0)
+
+    fireEvent.keyDown(svg, { key: 'End' })
+    expect(screen.getAllByText('Day 5').length).toBeGreaterThan(0)
+  })
+
+  it('labels the delta as on pace when actual matches the pace value', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [100, 200, 300],
+      budget: 1000,
+      monthLength: 10,
+      activeDay: 3,
+    }))
+
+    expect(screen.getAllByText('On pace').length).toBeGreaterThan(0)
+  })
+
+  it('labels the delta as over pace when actual exceeds expected pace', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [400, 800, 1200],
+      budget: 1000,
+      monthLength: 30,
+      activeDay: 3,
+    }))
+
+    expect(screen.getAllByText(/over pace/).length).toBeGreaterThan(0)
+  })
+
+  it('labels the delta as under pace when actual is below expected pace', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [10, 20, 30],
+      budget: 1200,
+      monthLength: 30,
+      activeDay: 3,
+    }))
+
+    expect(screen.getAllByText(/under pace/).length).toBeGreaterThan(0)
+  })
+
+  it('omits Pace and Budget when no budget is set', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [50, 100, 150],
+      budget: 0,
+      monthLength: 30,
+      activeDay: 3,
+    }))
+
+    expect(screen.queryByText('Pace')).toBeNull()
+    expect(screen.queryByText('Budget')).toBeNull()
+    expect(screen.queryByText('Status')).toBeNull()
+  })
+})

--- a/nextjs/__tests__/frontend/monthPacingChart.unit.test.js
+++ b/nextjs/__tests__/frontend/monthPacingChart.unit.test.js
@@ -113,4 +113,81 @@ describe('MonthPacingChart', () => {
     expect(screen.queryByText('Budget')).toBeNull()
     expect(screen.queryByText('Status')).toBeNull()
   })
+
+  it('moves the focused day when the pointer moves across the chart', () => {
+    const { container } = render(React.createElement(MonthPacingChart, {
+      trendPoints: [10, 20, 30, 40],
+      budget: 1000,
+      monthLength: 10,
+      activeDay: 4,
+    }))
+
+    const svg = screen.getByRole('img')
+    jest.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      width: 360,
+      height: 168,
+      top: 0,
+      left: 0,
+      right: 360,
+      bottom: 168,
+    })
+
+    fireEvent.mouseMove(svg, { clientX: 0 })
+    expect(screen.getAllByText('Day 1').length).toBeGreaterThan(0)
+
+    fireEvent.mouseMove(svg, { clientX: 360 })
+    expect(screen.getAllByText('Day 4').length).toBeGreaterThan(0)
+    expect(container.querySelector('.month-pacing--inspecting')).toBeTruthy()
+  })
+
+  it('clears keyboard hover and snaps back to the last day on Escape', () => {
+    render(React.createElement(MonthPacingChart, {
+      trendPoints: [5, 15, 25, 35],
+      budget: 1000,
+      monthLength: 10,
+      activeDay: 4,
+    }))
+
+    const svg = screen.getByRole('img')
+    jest.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      width: 360,
+      height: 168,
+      top: 0,
+      left: 0,
+      right: 360,
+      bottom: 168,
+    })
+
+    fireEvent.mouseMove(svg, { clientX: 0 })
+    expect(svg.getAttribute('aria-label')).toMatch(/Day 1:/)
+
+    fireEvent.keyDown(svg, { key: 'Escape' })
+    expect(svg.getAttribute('aria-label')).toMatch(/Day 4:/)
+  })
+
+  it('applies the over-budget class when the month is over budget on the last day', () => {
+    const { container } = render(React.createElement(MonthPacingChart, {
+      trendPoints: [10, 20, 300],
+      budget: 200,
+      monthLength: 10,
+      activeDay: 3,
+      isOverBudget: true,
+    }))
+
+    expect(container.querySelector('.month-pacing--over')).toBeTruthy()
+  })
+
+  it('draws more than one line segment when spend crosses the pace line between days', () => {
+    const { container } = render(React.createElement(MonthPacingChart, {
+      trendPoints: [200, 100],
+      budget: 200,
+      monthLength: 2,
+      activeDay: 2,
+    }))
+
+    const segments = container.querySelectorAll(
+      '.month-pacing__line--danger, .month-pacing__line--positive, .month-pacing__line--warning',
+    )
+    expect(segments.length).toBeGreaterThanOrEqual(2)
+  })
 })

--- a/nextjs/__tests__/frontend/paceVsLastMonthChart.unit.test.js
+++ b/nextjs/__tests__/frontend/paceVsLastMonthChart.unit.test.js
@@ -1,0 +1,117 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/lib/financeUtils', () => ({
+  formatCurrency: jest.fn((value) => {
+    const amount = Number(value)
+    if (!Number.isFinite(amount)) return '--'
+    return `$${amount.toFixed(2)}`
+  }),
+}))
+
+const React = require('react')
+const { render, screen, fireEvent, cleanup } = require('@testing-library/react')
+const { default: PaceVsLastMonthChart } = require('@/components/ui/PaceVsLastMonthChart')
+
+afterEach(() => {
+  cleanup()
+})
+
+function buildCumulative(amounts) {
+  let running = 0
+  return amounts.map((amount, index) => {
+    running += Number(amount)
+    return { day: index + 1, amount: running }
+  })
+}
+
+describe('PaceVsLastMonthChart', () => {
+  it('renders the empty state when neither month has activity', () => {
+    render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: [],
+      previousMonthSeries: [],
+    }))
+
+    expect(screen.getByText(/Month-over-month pace appears/i)).toBeTruthy()
+  })
+
+  it('renders both lines, the today divider, and the focused-day callout', () => {
+    const currentSeries = buildCumulative([40, 60, 30, 0, 50])
+    const previousSeries = buildCumulative([30, 20, 20, 40, 30, 20, 30])
+
+    const { container } = render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+      currentMonthLabel: 'March',
+      previousMonthLabel: 'February',
+      monthLength: 31,
+    }))
+
+    expect(container.querySelector('.pace-chart__line--current')).toBeTruthy()
+    expect(container.querySelector('.pace-chart__line--previous')).toBeTruthy()
+    expect(container.querySelector('.pace-chart__today-divider')).toBeTruthy()
+    expect(screen.getAllByText('March').length).toBeGreaterThan(0)
+    fireEvent.mouseEnter(container.querySelector('.pace-chart__plot'))
+    expect(screen.getAllByText(/Day 5/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/March \$180\.00/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/February \$140\.00/).length).toBeGreaterThan(0)
+  })
+
+  it('shifts the inspected day with arrow keys and updates the callout', () => {
+    const currentSeries = buildCumulative([40, 60, 30, 0, 50])
+    const previousSeries = buildCumulative([30, 20, 20, 40, 30])
+
+    render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+      currentMonthLabel: 'March',
+      previousMonthLabel: 'February',
+    }))
+
+    const svg = screen.getByRole('img')
+
+    fireEvent.keyDown(svg, { key: 'ArrowLeft' })
+    expect(screen.getAllByText(/Day 4/).length).toBeGreaterThan(0)
+
+    fireEvent.keyDown(svg, { key: 'Home' })
+    expect(screen.getAllByText(/Day 1/).length).toBeGreaterThan(0)
+
+    fireEvent.keyDown(svg, { key: 'End' })
+    expect(screen.getAllByText(/Day 5/).length).toBeGreaterThan(0)
+  })
+
+  it('labels the delta as faster or slower than last month based on the current vs previous endpoint', () => {
+    const currentSeries = buildCumulative([100, 100, 100])
+    const previousSeries = buildCumulative([50, 50, 50, 50, 50])
+
+    const { container, rerender } = render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+    }))
+
+    fireEvent.mouseEnter(container.querySelector('.pace-chart__plot'))
+    expect(screen.getAllByText(/Faster than last month/).length).toBeGreaterThan(0)
+
+    const slowerCurrent = buildCumulative([25, 25, 25])
+    const steadyPrevious = buildCumulative([50, 50, 50, 50, 50])
+    rerender(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: slowerCurrent,
+      previousMonthSeries: steadyPrevious,
+    }))
+
+    fireEvent.mouseEnter(container.querySelector('.pace-chart__plot'))
+    expect(screen.getAllByText(/Slower than last month/).length).toBeGreaterThan(0)
+  })
+
+  it('provides an aria-label on the svg for accessibility', () => {
+    const currentSeries = buildCumulative([40, 60])
+    const previousSeries = buildCumulative([30, 20, 40])
+    render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+      currentMonthLabel: 'March',
+      previousMonthLabel: 'February',
+    }))
+
+    expect(screen.getByRole('img', { name: /Cumulative spend March vs February/ })).toBeTruthy()
+  })
+})

--- a/nextjs/__tests__/frontend/paceVsLastMonthChart.unit.test.js
+++ b/nextjs/__tests__/frontend/paceVsLastMonthChart.unit.test.js
@@ -114,4 +114,73 @@ describe('PaceVsLastMonthChart', () => {
 
     expect(screen.getByRole('img', { name: /Cumulative spend March vs February/ })).toBeTruthy()
   })
+
+  it('renders from last month data when the current month has not recorded spend yet', () => {
+    const previousSeries = buildCumulative([25, 50, 100])
+    const { container } = render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: [],
+      previousMonthSeries: previousSeries,
+      currentMonthLabel: 'March',
+      previousMonthLabel: 'February',
+    }))
+
+    const root = container.querySelector('.pace-chart')
+    expect(root).toBeTruthy()
+    expect(root.classList.contains('pace-chart--empty')).toBe(false)
+    expect(root.getAttribute('data-has-previous')).toBe('true')
+    expect(container.querySelector('.pace-chart__line--previous')).toBeTruthy()
+  })
+
+  it('uses pointer movement to pick a day and clears inspection on Escape', () => {
+    const currentSeries = buildCumulative([20, 40, 60])
+    const previousSeries = buildCumulative([10, 20, 30])
+
+    const { container } = render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+    }))
+
+    const root = container.querySelector('.pace-chart')
+    const svg = screen.getByRole('img')
+    jest.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      width: 320,
+      height: 156,
+      top: 0,
+      left: 0,
+      right: 320,
+      bottom: 156,
+    })
+
+    fireEvent.mouseMove(svg, { clientX: 0 })
+    expect(root.classList.contains('pace-chart--inspecting')).toBe(true)
+    fireEvent.keyDown(svg, { key: 'Escape' })
+    expect(root.classList.contains('pace-chart--inspecting')).toBe(false)
+  })
+
+  it('uses the "on pace" copy when the gap to last month is under half a dollar', () => {
+    const currentSeries = buildCumulative([100, 200])
+    const previousSeries = buildCumulative([100, 199.8])
+
+    const { container } = render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+    }))
+
+    fireEvent.mouseEnter(container.querySelector('.pace-chart__plot'))
+    expect(screen.getAllByText(/On pace with last month/).length).toBeGreaterThan(0)
+  })
+
+  it('emits a warning segment when the current line jumps far above last month on the same day', () => {
+    const currentSeries = buildCumulative([5, 40])
+    const previousSeries = buildCumulative([2, 2])
+
+    const { container } = render(React.createElement(PaceVsLastMonthChart, {
+      currentMonthSeries: currentSeries,
+      previousMonthSeries: previousSeries,
+    }))
+
+    expect(
+      container.querySelector('.pace-chart__line--current.pace-chart__line--current-warning'),
+    ).toBeTruthy()
+  })
 })

--- a/nextjs/__tests__/frontend/transactionDetailSheet.unit.test.js
+++ b/nextjs/__tests__/frontend/transactionDetailSheet.unit.test.js
@@ -1,0 +1,146 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/lib/financeVisuals', () => ({
+  getEntryVisual: jest.fn(() => ({
+    color: '#102030',
+    soft: '#aabbcc',
+    symbol: '$',
+  })),
+}))
+
+jest.mock('@/lib/financeUtils', () => ({
+  formatCurrency: jest.fn((value) => {
+    const n = Number(value)
+    return Number.isFinite(n) ? `$${n.toFixed(2)}` : '$0.00'
+  }),
+  formatLongDate: jest.fn((value) => `Long date ${value}`),
+}))
+
+const React = require('react')
+const { render, screen, fireEvent, cleanup } = require('@testing-library/react')
+const { default: TransactionDetailSheet } = require('@/components/ui/TransactionDetailSheet')
+
+afterEach(() => {
+  cleanup()
+  jest.clearAllMocks()
+})
+
+describe('TransactionDetailSheet', () => {
+  it('renders nothing when entry is missing', () => {
+    const { container } = render(React.createElement(TransactionDetailSheet, { onClose: jest.fn() }))
+    expect(container.querySelector('.detail-overlay')).toBeNull()
+  })
+
+  it('invokes onClose from the header close button and the backdrop', () => {
+    const onClose = jest.fn()
+    render(React.createElement(TransactionDetailSheet, {
+      onClose,
+      entry: {
+        kind: 'expense',
+        title: 'Cafe',
+        merchant: 'Cafe',
+        occurredOn: '2026-03-12',
+        amount: 4,
+        chip: 'Dining',
+        note: '',
+      },
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Close transaction details' }))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows the merchant in the subtitle when it differs from the title', () => {
+    render(React.createElement(TransactionDetailSheet, {
+      onClose: jest.fn(),
+      entry: {
+        kind: 'expense',
+        title: 'Dining out',
+        merchant: 'Cafe on Main',
+        occurredOn: '2026-03-12',
+        amount: 12.5,
+        chip: 'Dining',
+        note: 'Team lunch',
+      },
+    }))
+
+    expect(screen.getByText('Cafe on Main')).toBeTruthy()
+  })
+
+  it('uses a long-form date in the subtitle when the merchant is not a separate display name', () => {
+    const { formatLongDate } = require('@/lib/financeUtils')
+    render(React.createElement(TransactionDetailSheet, {
+      onClose: jest.fn(),
+      entry: {
+        kind: 'expense',
+        title: 'Small shop',
+        merchant: 'Small shop',
+        occurredOn: '2026-04-15',
+        amount: 8,
+        chip: 'Dining',
+        note: 'Dining',
+      },
+    }))
+
+    expect(formatLongDate).toHaveBeenCalled()
+    expect(document.querySelector('.detail-sheet__subtitle').textContent).toBe('Long date 2026-04-15')
+  })
+
+  it('displays a distinct body note for expenses when the note is not the category chip', () => {
+    render(React.createElement(TransactionDetailSheet, {
+      onClose: jest.fn(),
+      entry: {
+        kind: 'expense',
+        title: 'Store',
+        merchant: 'Store',
+        occurredOn: '2026-01-20',
+        amount: 19.99,
+        chip: 'Shopping',
+        note: 'Gift card for Alex',
+      },
+    }))
+
+    const noteCell = screen.getByText('Note').parentElement
+    expect(noteCell.querySelector('strong').textContent).toBe('Gift card for Alex')
+  })
+
+  it('shows a neutral income note and plus formatting for income', () => {
+    render(React.createElement(TransactionDetailSheet, {
+      onClose: jest.fn(),
+      entry: {
+        kind: 'income',
+        title: 'Payday',
+        merchant: 'Acme',
+        occurredOn: '2026-03-01',
+        amount: 2500,
+        chip: 'Income',
+        note: 'Income',
+      },
+    }))
+
+    expect(screen.getByText('No note added').closest('strong')).toBeTruthy()
+    expect(screen.getByText(/\+.*2500/)).toBeTruthy()
+  })
+
+  it('passes through extra detail content in children', () => {
+    render(React.createElement(
+      TransactionDetailSheet,
+      {
+        onClose: jest.fn(),
+        entry: {
+          kind: 'expense',
+          title: 'A',
+          merchant: 'A',
+          occurredOn: '2026-01-01',
+          amount: 1,
+          chip: 'C',
+        },
+        children: React.createElement('p', { 'data-testid': 'extra' }, 'Extra copy'),
+      },
+    ))
+
+    expect(screen.getByTestId('extra').textContent).toBe('Extra copy')
+  })
+})

--- a/nextjs/__tests__/frontend/transactions.test.js
+++ b/nextjs/__tests__/frontend/transactions.test.js
@@ -1,0 +1,174 @@
+/** @jest-environment jsdom */
+
+jest.mock('next/navigation', () => ({ useRouter: jest.fn() }))
+jest.mock('@/components/providers', () => ({
+  useAuth: jest.fn(),
+  useDataMode: jest.fn(),
+  useDataChanged: jest.fn(),
+}))
+jest.mock('@/lib/apiClient', () => ({
+  ApiError: class ApiError extends Error {
+    constructor(message = 'API error', status) {
+      super(message)
+      this.status = status
+    }
+  },
+  apiGet: jest.fn(),
+  apiPost: jest.fn(),
+}))
+jest.mock('@/lib/demoData', () => ({
+  demoActivity: [
+    {
+      id: 'mock-expense-lab-coffee',
+      kind: 'expense',
+      merchant: 'Lab Coffee House',
+      title: 'Lab Coffee House',
+      chip: 'Dining',
+      occurredOn: '2026-03-15',
+      amount: 12.4,
+      note: 'Breakfast before class',
+    },
+    {
+      id: 'mock-expense-market',
+      kind: 'expense',
+      merchant: 'Mockville Market',
+      title: 'Mockville Market',
+      chip: 'Groceries',
+      occurredOn: '2026-03-16',
+      amount: 61.47,
+      note: 'Produce and snacks',
+    },
+    {
+      id: 'mock-income-payroll',
+      kind: 'income',
+      merchant: 'Mockville Payroll',
+      title: 'Mockville Payroll',
+      chip: 'Income',
+      occurredOn: '2026-03-01',
+      amount: 2400,
+      note: '',
+    },
+  ],
+}))
+jest.mock('@/lib/financeVisuals', () => ({
+  getCategoryVisual: jest.fn((value) => ({
+    label: value,
+    color: '#123456',
+    soft: '#abcdef',
+    symbol: value?.[0] || '?',
+  })),
+  getEntryVisual: jest.fn((entry) => ({
+    color: entry.kind === 'income' ? '#0f9d58' : '#123456',
+    soft: '#abcdef',
+    symbol: entry.kind === 'income' ? '+' : '$',
+  })),
+}))
+jest.mock('@/lib/financeUtils', () => ({
+  buildActivityFeed: jest.fn(),
+  formatCurrency: jest.fn((value) => `$${value}`),
+  formatLongDate: jest.fn((value) => `Long ${value}`),
+  formatShortDate: jest.fn((value) => value),
+  groupActivityByDate: jest.fn((entries) => {
+    const grouped = new Map()
+    entries.forEach((entry) => {
+      const key = entry.occurredOn
+      if (!grouped.has(key)) grouped.set(key, { key, label: `On ${key}`, entries: [] })
+      grouped.get(key).entries.push(entry)
+    })
+    return Array.from(grouped.values()).sort((left, right) => right.key.localeCompare(left.key))
+  }),
+}))
+
+const React = require('react')
+const { render, screen, fireEvent, cleanup, act } = require('@testing-library/react')
+const { useRouter } = require('next/navigation')
+const { useAuth, useDataMode, useDataChanged } = require('@/components/providers')
+const { default: TransactionsView } = require('@/components/transactions-view')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  useRouter.mockReturnValue({ replace: jest.fn() })
+  useAuth.mockReturnValue({
+    isReady: true,
+    logout: jest.fn(),
+    session: {
+      accessToken: 'token',
+      user: { email: 'sam@example.com' },
+    },
+  })
+  useDataMode.mockReturnValue({ isSampleMode: true })
+  useDataChanged.mockReturnValue({ dataChangedToken: 0, notifyDataChanged: jest.fn() })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('TransactionsView (sample data)', () => {
+  it('renders the grouped activity feed with expenses and income rows', () => {
+    render(React.createElement(TransactionsView))
+    expect(screen.getByRole('heading', { name: 'Transactions' })).toBeTruthy()
+    expect(screen.getByText('Lab Coffee House')).toBeTruthy()
+    expect(screen.getByText('Mockville Market')).toBeTruthy()
+    expect(screen.getByText('Mockville Payroll')).toBeTruthy()
+  })
+
+  it('filters to expenses only when the Expenses segment is selected', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Expenses' }))
+    })
+    expect(screen.queryByText('Mockville Payroll')).toBeNull()
+    expect(screen.getByText('Lab Coffee House')).toBeTruthy()
+  })
+
+  it('filters to income only when the Income segment is selected', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Income' }))
+    })
+    expect(screen.queryByText('Lab Coffee House')).toBeNull()
+    expect(screen.getByText('Mockville Payroll')).toBeTruthy()
+  })
+
+  it('narrows results when the search field is used', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.change(screen.getByPlaceholderText(/Search merchant/i), { target: { value: 'mockville market' } })
+    })
+    expect(screen.getByText('Mockville Market')).toBeTruthy()
+    expect(screen.queryByText('Lab Coffee House')).toBeNull()
+  })
+
+  it('opens a detail sheet when a row is clicked and closes it on close button', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.click(screen.getByText('Lab Coffee House'))
+    })
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Lab Coffee House' })).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not repeat the chip text inside the detail sheet subtitle when merchant matches title', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.click(screen.getByText('Mockville Payroll'))
+    })
+    const subtitle = document.querySelector('.detail-sheet__subtitle')
+    expect(subtitle).toBeTruthy()
+    expect(subtitle.textContent).not.toBe('Income')
+  })
+
+  it('shows a kind-specific empty message when filters produce no results', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.change(screen.getByPlaceholderText(/Search merchant/i), { target: { value: 'zzzzz' } })
+    })
+    expect(screen.getByText('No matching transactions')).toBeTruthy()
+  })
+})

--- a/nextjs/__tests__/frontend/transactions.test.js
+++ b/nextjs/__tests__/frontend/transactions.test.js
@@ -131,7 +131,7 @@ describe('TransactionsView (sample data)', () => {
     expect(screen.getByText('Mockville Payroll')).toBeTruthy()
   })
 
-  it('narrows results when the search field is used', () => {
+  it('filters the list when searching for mockville market', () => {
     render(React.createElement(TransactionsView))
     act(() => {
       fireEvent.change(screen.getByPlaceholderText(/Search merchant/i), { target: { value: 'mockville market' } })
@@ -150,6 +150,19 @@ describe('TransactionsView (sample data)', () => {
 
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('closes the detail sheet when the backdrop control is activated', () => {
+    render(React.createElement(TransactionsView))
+    act(() => {
+      fireEvent.click(screen.getByText('Lab Coffee House'))
+    })
+    expect(screen.getByRole('dialog')).toBeTruthy()
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Close transaction details' }))
     })
     expect(screen.queryByRole('dialog')).toBeNull()
   })

--- a/nextjs/__tests__/frontend/trendChartAxes.unit.test.js
+++ b/nextjs/__tests__/frontend/trendChartAxes.unit.test.js
@@ -1,0 +1,46 @@
+/** @jest-environment jsdom */
+
+const React = require('react')
+const { render, cleanup } = require('@testing-library/react')
+const { default: TrendChartAxes } = require('@/components/ui/TrendChartAxes')
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderInSvg(ui) {
+  return render(React.createElement('svg', { xmlns: 'http://www.w3.org/2000/svg' }, ui))
+}
+
+describe('TrendChartAxes', () => {
+  it('renders null when axes are missing', () => {
+    const { container } = renderInSvg(React.createElement(TrendChartAxes, { axes: null }))
+    expect(container.querySelector('g')).toBeNull()
+  })
+
+  it('renders the budget and pace lines when the axes object includes them', () => {
+    const { container } = renderInSvg(React.createElement(TrendChartAxes, {
+      axes: {
+        budgetLineY: 24,
+        plotLeft: 10,
+        plotRight: 300,
+        paceLine: { startX: 10, endX: 280, startY: 100, endY: 20 },
+      },
+    }))
+
+    const group = container.querySelector('g.trend-chart__axes')
+    expect(group).toBeTruthy()
+    expect(group.querySelector('.trend-chart__budget-line')).toBeTruthy()
+    expect(group.querySelector('.trend-chart__pace-line')).toBeTruthy()
+  })
+
+  it('renders only the budget line when pace is absent', () => {
+    const { container } = renderInSvg(React.createElement(TrendChartAxes, {
+      axes: { budgetLineY: 20, plotLeft: 0, plotRight: 200, paceLine: null },
+    }))
+
+    const group = container.querySelector('g.trend-chart__axes')
+    expect(group.querySelector('.trend-chart__budget-line')).toBeTruthy()
+    expect(group.querySelector('.trend-chart__pace-line')).toBeNull()
+  })
+})

--- a/nextjs/e2e/auth.spec.js
+++ b/nextjs/e2e/auth.spec.js
@@ -1,9 +1,12 @@
 const { test, expect } = require('@playwright/test')
 
+const TEST_EMAIL = 'tester@gmail.com'
+const TEST_PASSWORD = 'tester123'
+
 test('user can sign in and reach the dashboard', async ({ page }) => {
   await page.goto('/login')
-  await page.getByLabel('Email').fill('tester@gmail.com')
-  await page.getByLabel('Password').fill('tester123')
+  await page.getByLabel('Email').fill(TEST_EMAIL)
+  await page.getByLabel('Password').fill(TEST_PASSWORD)
   await page.getByRole('button', { name: 'Log in' }).click()
 
   await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })

--- a/nextjs/e2e/auth.spec.js
+++ b/nextjs/e2e/auth.spec.js
@@ -10,5 +10,11 @@ test('user can sign in and reach the dashboard', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'Budgets' })).toBeVisible()
   await expect(page.getByText('Recent activity')).toBeVisible()
-  await expect(page.getByText('Recent income')).toBeVisible()
+
+  const activityFilter = page.locator('.dashboard-activity-filter')
+  const incomeFilter = activityFilter.getByRole('button', { name: 'Income' })
+
+  await expect(incomeFilter).toBeVisible()
+  await incomeFilter.click()
+  await expect(incomeFilter).toHaveAttribute('aria-pressed', 'true')
 })

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -21,6 +21,11 @@
   --danger-soft: rgba(183, 95, 103, 0.12);
   --success: #4f7b61;
   --success-soft: rgba(79, 123, 97, 0.12);
+  --watch-amber: #b89a45;
+  --watch-amber-soft: rgba(184, 154, 69, 0.14);
+  --near-limit-orange: #c9825a;
+  --near-limit-orange-soft: rgba(201, 130, 90, 0.14);
+  --chart-pace: #b8773a;
   --radius-card: 32px;
   --radius-pill: 999px;
   --shell-width: 35rem;
@@ -2447,6 +2452,18 @@ html[data-theme='dark'] .tab-link--active::after {
   --shadow-card: 0 18px 36px rgba(43, 59, 50, 0.08);
   --warning: #c9825a;
   --warning-soft: rgba(201, 130, 90, 0.14);
+  --status-positive: #5f8f70;
+  --status-positive-soft: rgba(95, 143, 112, 0.13);
+  --status-positive-border: rgba(95, 143, 112, 0.24);
+  --status-watch: #b89a45;
+  --status-watch-soft: rgba(184, 154, 69, 0.14);
+  --status-watch-border: rgba(184, 154, 69, 0.3);
+  --status-near: #c9825a;
+  --status-near-soft: rgba(201, 130, 90, 0.14);
+  --status-near-border: rgba(201, 130, 90, 0.32);
+  --status-over: #b75f67;
+  --status-over-soft: rgba(183, 95, 103, 0.13);
+  --status-over-border: rgba(183, 95, 103, 0.34);
 }
 
 html[data-theme='dark'] {
@@ -2459,6 +2476,18 @@ html[data-theme='dark'] {
   --shadow-card: 0 18px 40px rgba(0, 0, 0, 0.28);
   --warning: #f0a97f;
   --warning-soft: rgba(240, 169, 127, 0.14);
+  --status-positive: #aed1b9;
+  --status-positive-soft: rgba(174, 209, 185, 0.12);
+  --status-positive-border: rgba(174, 209, 185, 0.22);
+  --status-watch: #e2c575;
+  --status-watch-soft: rgba(226, 197, 117, 0.13);
+  --status-watch-border: rgba(226, 197, 117, 0.28);
+  --status-near: #f0a97f;
+  --status-near-soft: rgba(240, 169, 127, 0.13);
+  --status-near-border: rgba(240, 169, 127, 0.3);
+  --status-over: #f0a4aa;
+  --status-over-soft: rgba(240, 164, 170, 0.13);
+  --status-over-border: rgba(240, 164, 170, 0.32);
 }
 
 body {
@@ -3031,6 +3060,21 @@ html[data-theme='dark'] .insight-pocket__row {
   background: linear-gradient(180deg, var(--surface-panel-strong), var(--surface-panel));
   box-shadow: 0 10px 24px rgba(45, 60, 52, 0.05);
   transition: transform 180ms ease, border-color 180ms ease;
+}
+
+button.activity-feed__row {
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  appearance: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+button.activity-feed__row:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
 }
 
 .activity-feed__row:hover,
@@ -3755,6 +3799,10 @@ html[data-theme='dark'] .tab-link--active {
   display: grid;
   gap: 1rem;
   align-items: start;
+}
+
+.dashboard-grid {
+  align-items: stretch;
 }
 
 .budget-glance {
@@ -6731,19 +6779,19 @@ html[data-theme='dark'] .planner-row {
 }
 
 .planner-row--positive {
-  border-color: rgba(79, 123, 97, 0.2);
-  background: linear-gradient(180deg, rgba(79, 123, 97, 0.08), rgba(255, 255, 255, 0.44));
+  border-color: var(--status-positive-border);
+  background: linear-gradient(180deg, var(--status-positive-soft), rgba(255, 255, 255, 0.44));
 }
 
 .planner-row--warning {
-  border-color: rgba(201, 130, 90, 0.42);
-  background: linear-gradient(180deg, rgba(201, 130, 90, 0.12), rgba(255, 255, 255, 0.46));
+  border-color: var(--status-near-border);
+  background: linear-gradient(180deg, var(--status-near-soft), rgba(255, 255, 255, 0.46));
 }
 
 .planner-row--danger {
-  border-color: rgba(183, 95, 103, 0.48);
-  background: linear-gradient(180deg, rgba(183, 95, 103, 0.14), rgba(255, 255, 255, 0.5));
-  box-shadow: 0 0 0 1px rgba(183, 95, 103, 0.08), 0 14px 26px rgba(183, 95, 103, 0.08);
+  border-color: var(--status-over-border);
+  background: linear-gradient(180deg, var(--status-over-soft), rgba(255, 255, 255, 0.5));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--status-over) 14%, transparent), 0 14px 26px color-mix(in srgb, var(--status-over) 12%, transparent);
 }
 
 .planner-row__top,
@@ -6799,9 +6847,9 @@ html[data-theme='dark'] .planner-row {
 }
 
 .planner-status--positive {
-  background: rgba(79, 123, 97, 0.16);
-  border-color: rgba(79, 123, 97, 0.24);
-  color: var(--success);
+  background: var(--status-positive-soft);
+  border-color: var(--status-positive-border);
+  color: var(--status-positive);
 }
 
 .planner-status--neutral {
@@ -6810,15 +6858,15 @@ html[data-theme='dark'] .planner-row {
 }
 
 .planner-status--warning {
-  background: rgba(201, 130, 90, 0.18);
-  border-color: rgba(201, 130, 90, 0.28);
-  color: var(--warning);
+  background: var(--status-near-soft);
+  border-color: var(--status-near-border);
+  color: var(--status-near);
 }
 
 .planner-status--danger {
-  background: rgba(183, 95, 103, 0.18);
-  border-color: rgba(183, 95, 103, 0.3);
-  color: var(--danger);
+  background: var(--status-over-soft);
+  border-color: var(--status-over-border);
+  color: var(--status-over);
 }
 
 .planner-row__metrics {
@@ -6862,13 +6910,13 @@ html[data-theme='dark'] .planner-row__progress-track {
 }
 
 .planner-row__progress-fill--warning {
-  background: linear-gradient(135deg, #f0ba62, #d8832d);
-  box-shadow: 0 10px 18px rgba(216, 131, 45, 0.26);
+  background: linear-gradient(135deg, var(--status-near), color-mix(in srgb, var(--status-near) 74%, white 26%));
+  box-shadow: 0 10px 18px color-mix(in srgb, var(--status-near) 24%, transparent);
 }
 
 .planner-row__progress-fill--danger {
-  background: linear-gradient(135deg, #e57d88, #b44654);
-  box-shadow: 0 10px 20px rgba(183, 70, 84, 0.32);
+  background: linear-gradient(135deg, var(--status-over), color-mix(in srgb, var(--status-over) 74%, white 26%));
+  box-shadow: 0 10px 20px color-mix(in srgb, var(--status-over) 26%, transparent);
 }
 
 .planner-row__progress-fill--neutral {
@@ -6963,10 +7011,10 @@ html[data-theme='dark'] .planner-row__progress-track {
   --insights-metric-accent-bg: color-mix(in srgb, var(--text-primary) 8%, var(--surface-panel-soft) 92%);
   --insights-metric-net-accent: color-mix(in srgb, var(--success) 28%, var(--text-secondary) 72%);
   --insights-focus-ring: color-mix(in srgb, var(--accent) 35%, var(--border));
-  --insights-success: #7ac192;
-  --insights-caution: #d6b350;
-  --insights-warning: #ee9340;
-  --insights-danger: #de6f74;
+  --insights-success: var(--status-positive);
+  --insights-caution: var(--status-watch);
+  --insights-warning: var(--status-near);
+  --insights-danger: var(--status-over);
   display: grid;
   gap: 1rem;
 }
@@ -7118,6 +7166,23 @@ html[data-theme='dark'] .insights-screen--issue57 {
   align-items: flex-start;
 }
 
+.insights-screen--issue57 .insights-v57__cashflow-header-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  text-align: right;
+  min-width: 0;
+}
+
+.insights-screen--issue57 .insights-v57__cashflow-header-note {
+  max-width: 16rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
 .insights-screen--issue57 .insights-v57__title,
 .insights-screen--issue57 .insights-v57__panel-head h3 {
   margin: 0;
@@ -7186,7 +7251,7 @@ html[data-theme='dark'] .insights-screen--issue57 {
 .insights-screen--issue57 .insights-v57__donut-shell {
   display: grid;
   place-items: center;
-  padding: 1.35rem 0 1.6rem;
+  padding: 0.25rem 0 1rem;
 }
 
 .insights-screen--issue57 .insights-v57__donut {
@@ -7395,33 +7460,33 @@ html[data-theme='dark'] .insights-screen--issue57 {
 .insights-screen--issue57 .insights-v57__status-chip--positive,
 .insights-screen--issue57 .insights-v57__metric-delta--positive,
 .insights-screen--issue57 .insights-v57__mover-delta--positive {
-  color: var(--insights-success);
-  background: rgba(122, 193, 146, 0.12);
-  border-color: rgba(122, 193, 146, 0.2);
+  color: var(--status-positive);
+  background: var(--status-positive-soft);
+  border-color: var(--status-positive-border);
 }
 
 .insights-screen--issue57 .insights-v57__status-chip--caution,
 .insights-screen--issue57 .insights-v57__metric-delta--caution,
 .insights-screen--issue57 .insights-v57__mover-delta--caution {
-  color: var(--insights-caution);
-  background: rgba(214, 179, 80, 0.12);
-  border-color: rgba(214, 179, 80, 0.2);
+  color: var(--status-watch);
+  background: var(--status-watch-soft);
+  border-color: var(--status-watch-border);
 }
 
 .insights-screen--issue57 .insights-v57__status-chip--warning,
 .insights-screen--issue57 .insights-v57__metric-delta--warning,
 .insights-screen--issue57 .insights-v57__mover-delta--warning {
-  color: var(--insights-warning);
-  background: rgba(238, 147, 64, 0.12);
-  border-color: rgba(238, 147, 64, 0.2);
+  color: var(--status-near);
+  background: var(--status-near-soft);
+  border-color: var(--status-near-border);
 }
 
 .insights-screen--issue57 .insights-v57__status-chip--danger,
 .insights-screen--issue57 .insights-v57__metric-delta--danger,
 .insights-screen--issue57 .insights-v57__mover-delta--danger {
-  color: var(--insights-danger);
-  background: rgba(222, 111, 116, 0.12);
-  border-color: rgba(222, 111, 116, 0.2);
+  color: var(--status-over);
+  background: var(--status-over-soft);
+  border-color: var(--status-over-border);
 }
 
 .insights-screen--issue57 .insights-v57__status-chip--neutral,
@@ -7456,28 +7521,28 @@ html[data-theme='dark'] .insights-screen--issue57 {
 .insights-screen--issue57 .insights-v57__budget-progress-fill--positive,
 .insights-screen--issue57 .insights-v57__pressure-progress-fill--positive,
 .insights-screen--issue57 .insights-v57__mover-meter-fill--positive {
-  background: linear-gradient(90deg, rgba(111, 170, 128, 0.9), #7ac192);
+  background: linear-gradient(90deg, var(--status-positive), color-mix(in srgb, var(--status-positive) 72%, white 28%));
 }
 
 .insights-screen--issue57 .insights-v57__category-progress-fill--caution,
 .insights-screen--issue57 .insights-v57__budget-progress-fill--caution,
 .insights-screen--issue57 .insights-v57__pressure-progress-fill--caution,
 .insights-screen--issue57 .insights-v57__mover-meter-fill--caution {
-  background: linear-gradient(90deg, rgba(214, 179, 80, 0.95), #edd167);
+  background: linear-gradient(90deg, var(--status-watch), color-mix(in srgb, var(--status-watch) 74%, white 26%));
 }
 
 .insights-screen--issue57 .insights-v57__category-progress-fill--warning,
 .insights-screen--issue57 .insights-v57__budget-progress-fill--warning,
 .insights-screen--issue57 .insights-v57__pressure-progress-fill--warning,
 .insights-screen--issue57 .insights-v57__mover-meter-fill--warning {
-  background: linear-gradient(90deg, rgba(238, 147, 64, 0.95), #f5aa56);
+  background: linear-gradient(90deg, var(--status-near), color-mix(in srgb, var(--status-near) 76%, white 24%));
 }
 
 .insights-screen--issue57 .insights-v57__category-progress-fill--danger,
 .insights-screen--issue57 .insights-v57__budget-progress-fill--danger,
 .insights-screen--issue57 .insights-v57__pressure-progress-fill--danger,
 .insights-screen--issue57 .insights-v57__mover-meter-fill--danger {
-  background: linear-gradient(90deg, rgba(222, 111, 116, 0.95), #e8898d);
+  background: linear-gradient(90deg, var(--status-over), color-mix(in srgb, var(--status-over) 76%, white 24%));
 }
 
 .insights-screen--issue57 .insights-v57__category-meta {
@@ -7862,12 +7927,12 @@ html[data-theme='dark'] .insights-screen--issue57 {
 }
 
 .insights-screen--issue57 .insights-v57__metric-card {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  gap: 0.42rem;
-  align-content: start;
-  min-height: 6.65rem;
-  padding: 0.68rem 1rem 0.72rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.45rem;
+  min-height: 5.8rem;
+  padding: 0.85rem 1.1rem;
 }
 
 .insights-screen--issue57 .insights-v57__metric-card--income {
@@ -7934,10 +7999,16 @@ html[data-theme='dark'] .insights-screen--issue57 {
 }
 
 .insights-screen--issue57 .insights-v57__metric-value {
-  align-self: center;
+  margin: 0;
+  display: block;
+  align-self: flex-start;
+  min-height: unset;
+  padding: 0;
   font-size: 1.95rem;
   letter-spacing: -0.05em;
   line-height: 0.95;
+  margin-top: auto;
+  margin-bottom: 0.15rem;
 }
 
 .insights-screen--issue57 .insights-v57__metric-card .insights-v57__metric-head {
@@ -7959,6 +8030,26 @@ html[data-theme='dark'] .insights-screen--issue57 {
   border: 1px solid var(--insights-card-border);
   border-radius: 1.6rem;
   background: var(--insights-fill-raised);
+}
+
+.insights-screen--issue57 .insights-v57__budget-overview--positive {
+  border-color: var(--status-positive-border);
+  background: linear-gradient(180deg, var(--status-positive-soft), var(--insights-fill-raised));
+}
+
+.insights-screen--issue57 .insights-v57__budget-overview--caution {
+  border-color: var(--status-watch-border);
+  background: linear-gradient(180deg, var(--status-watch-soft), var(--insights-fill-raised));
+}
+
+.insights-screen--issue57 .insights-v57__budget-overview--warning {
+  border-color: var(--status-near-border);
+  background: linear-gradient(180deg, var(--status-near-soft), var(--insights-fill-raised));
+}
+
+.insights-screen--issue57 .insights-v57__budget-overview--danger {
+  border-color: var(--status-over-border);
+  background: linear-gradient(180deg, var(--status-over-soft), var(--insights-fill-raised));
 }
 
 .insights-screen--issue57 .insights-v57__budget-overview-copy {
@@ -8041,12 +8132,38 @@ html[data-theme='dark'] .insights-screen--issue57 {
   padding: 0.95rem;
 }
 
+.insights-screen--issue57 .insights-v57__mover-row--positive {
+  border-color: var(--status-positive-border);
+  background: linear-gradient(180deg, var(--status-positive-soft), var(--insights-fill-veil));
+}
+
+.insights-screen--issue57 .insights-v57__mover-row--caution {
+  border-color: var(--status-watch-border);
+  background: linear-gradient(180deg, var(--status-watch-soft), var(--insights-fill-veil));
+}
+
+.insights-screen--issue57 .insights-v57__mover-row--warning {
+  border-color: var(--status-near-border);
+  background: linear-gradient(180deg, var(--status-near-soft), var(--insights-fill-veil));
+}
+
+.insights-screen--issue57 .insights-v57__mover-row--danger {
+  border-color: var(--status-over-border);
+  background: linear-gradient(180deg, var(--status-over-soft), var(--insights-fill-veil));
+}
+
 .insights-screen--issue57 .insights-v57__pressure-head,
-.insights-screen--issue57 .insights-v57__mover-head,
 .insights-screen--issue57 .insights-v57__top-expense-head {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.insights-screen--issue57 .insights-v57__mover-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
   gap: 0.7rem;
 }
 
@@ -8241,6 +8358,50 @@ html[data-theme='dark'] .insights-screen--issue57 {
   color: var(--text-secondary);
   font-size: 0.84rem;
   padding: 0.05rem 0.05rem 0;
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-top-expenses {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 0.15rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--insights-card-border);
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-top-expenses-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-top-expenses-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: var(--text-primary);
+}
+
+.insights-screen--issue57 .insights-v57__top-expenses-more {
+  flex: 0 0 auto;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--accent-strong);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.insights-screen--issue57 .insights-v57__top-expenses-more:hover {
+  text-decoration: underline;
+}
+
+.insights-screen--issue57 .insights-v57__top-expense-list--nested {
+  gap: 0.55rem;
+}
+
+.insights-screen--issue57 .insights-v57__top-expense-list--nested .insights-v57__top-expense-head {
+  gap: 0.55rem;
 }
 
 .insights-screen--issue57 .insights-v57__panel-head--expenses {
@@ -8743,3 +8904,2114 @@ html[data-theme='dark'] .insights-screen--issue57 {
   }
 }
 
+/* Issue #59 hierarchy pass Â flatten the dashboard hero + new shared
+   primitives (AllocationBar, CategoryProgressRow, BudgetHudMetrics,
+   FinancialHealthTile, CashFlowSnapshot, PaceVsLastMonthChart,
+   TrendChartAxes). Everything below is scoped to new classes or tightly-scoped
+   overrides for the classes this PR intentionally flattens. */
+
+/* --------------------------------------------------------------------
+   Flatten the budget-hero: remove card-in-card chrome, tighten spacing
+   -------------------------------------------------------------------- */
+
+.dashboard-screen .budget-hero {
+  gap: 1rem;
+  padding: 1.4rem 1.4rem 1.25rem;
+  border-radius: 1.85rem;
+}
+
+.dashboard-screen .budget-hero__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.dashboard-screen .budget-hero__eyebrow {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.dashboard-screen .budget-hero__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.dashboard-screen .budget-hero__headline {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.dashboard-screen .budget-hero__value {
+  font-size: clamp(2.1rem, 7vw, 2.8rem);
+}
+
+/* Remove the nested rounded tile backgrounds from the hero metrics.
+   The metrics now sit on the same flat hero surface via BudgetHudMetrics. */
+.dashboard-screen .budget-hero__metrics {
+  display: none;
+}
+
+/* AllocationBar (shared) */
+.allocation-bar {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(122, 136, 127, 0.12);
+  overflow: visible;
+}
+
+.allocation-bar__fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 420ms ease;
+}
+
+.allocation-bar__fill--positive { background: var(--status-positive, var(--success)); }
+.allocation-bar__fill--caution { background: var(--status-watch, #b8952e); }
+.allocation-bar__fill--warning { background: var(--status-near, #c9825a); }
+.allocation-bar__fill--danger { background: var(--status-over, var(--danger)); }
+.allocation-bar__fill--neutral { background: var(--accent); }
+
+.allocation-bar--over .allocation-bar__fill {
+  box-shadow: inset 0 0 0 1px rgba(183, 95, 103, 0.55);
+}
+
+.allocation-bar__marker {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
+  background: var(--text-secondary);
+  opacity: 0.85;
+  border-radius: 2px;
+  transform: translateX(-1px);
+  pointer-events: none;
+}
+
+html[data-theme='dark'] .allocation-bar {
+  background: rgba(255, 255, 255, 0.07);
+}
+html[data-theme='dark'] .allocation-bar__marker {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+/* BudgetHudMetrics */
+.budget-hud-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem 1.25rem;
+  margin: 0.25rem 0 0;
+  padding: 0.65rem 0;
+  border-top: 1px solid var(--divider-soft);
+}
+
+.budget-hud-metrics__item {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.budget-hud-metrics__label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.budget-hud-metrics__value {
+  margin: 0;
+  display: grid;
+  gap: 0.08rem;
+}
+
+.budget-hud-metrics__value strong {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.budget-hud-metrics__hint {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 700px) {
+  .budget-hud-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.9rem 1rem;
+  }
+}
+
+/* --------------------------------------------------------------------
+   Dashboard At-a-glance row (FinancialHealthTile)
+   -------------------------------------------------------------------- */
+
+.dashboard-glance {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1rem;
+  margin: 0.25rem 0 1rem;
+}
+
+.dashboard-glance--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (max-width: 720px) {
+  .dashboard-glance {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.health-tile,
+.cashflow-snapshot,
+.trend-chart-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.15rem 1.2rem;
+  border-radius: 1.6rem;
+  border: 1px solid var(--divider-soft);
+  background: linear-gradient(180deg, var(--surface-panel-strong), var(--surface-panel));
+  box-shadow: var(--shadow-card);
+}
+
+.health-tile__header,
+.cashflow-snapshot__header {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.health-tile__eyebrow,
+.cashflow-snapshot__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.health-tile__label,
+.cashflow-snapshot__title {
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+/* FinancialHealthTile stacked bar */
+.health-tile__bar {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(122, 136, 127, 0.08);
+  overflow: hidden;
+}
+
+.health-tile__segment {
+  height: 100%;
+  transition: width 420ms ease;
+}
+
+.health-tile__segment--income {
+  background: var(--success, var(--accent));
+}
+
+.health-tile__segment--expense {
+  background: var(--danger, #b75f67);
+  opacity: 0.82;
+}
+
+.health-tile__legend {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.health-tile__legend div {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.health-tile__legend dt {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.health-tile__legend dd {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.health-tile__placeholder {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.health-tile__net {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--divider-soft);
+}
+
+.health-tile__net span {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.health-tile__net strong {
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.health-tile--positive { border-color: rgba(122, 181, 146, 0.28); }
+.health-tile--positive .health-tile__net strong { color: var(--success, var(--accent)); }
+.health-tile--danger { border-color: rgba(183, 95, 103, 0.3); }
+.health-tile--danger .health-tile__net strong { color: var(--danger, #b75f67); }
+.health-tile--warning { border-color: rgba(201, 130, 90, 0.26); }
+
+html[data-theme='dark'] .health-tile__bar {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* --------------------------------------------------------------------
+   CategoryProgressRow (shared)
+   -------------------------------------------------------------------- */
+
+.category-progress-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.category-progress-list--compact {
+  gap: 0.45rem;
+}
+
+.category-progress-list--compact .category-progress-row {
+  grid-template-columns: minmax(8rem, 1fr) 1fr minmax(4.5rem, auto);
+  padding: 0.65rem 0.8rem;
+  gap: 0.5rem;
+}
+
+.category-progress-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(11rem, 1.25fr) 1fr minmax(6rem, 1.25fr);
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1rem;
+  border-radius: 1.1rem;
+  border: 1px solid var(--divider-soft);
+  background: var(--surface-panel);
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.category-progress-row__title-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.category-progress-row:hover {
+  border-color: rgba(122, 181, 146, 0.32);
+}
+
+.category-progress-row__main {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  min-width: 0;
+}
+
+.category-progress-row__icon {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background: var(--entry-soft);
+  color: var(--entry-color);
+  font-size: 1.1rem;
+}
+
+.category-progress-row__copy {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.category-progress-row__copy strong {
+  font-size: 0.98rem;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category-progress-row__copy small {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.category-progress-row__bar {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(122, 136, 127, 0.12);
+  overflow: hidden;
+}
+
+.category-progress-row__bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--entry-color);
+  transition: width 380ms ease;
+}
+
+.category-progress-row__bar-fill--positive { background: var(--status-positive, var(--success)); }
+.category-progress-row__bar-fill--warning { background: linear-gradient(90deg, var(--status-near, #c9825a), color-mix(in srgb, var(--status-near, #c9825a) 76%, white 24%)); }
+.category-progress-row__bar-fill--caution { background: linear-gradient(90deg, var(--status-watch, #b8952e), color-mix(in srgb, var(--status-watch, #b8952e) 74%, white 26%)); }
+.category-progress-row__bar-fill--danger { background: var(--status-over, var(--danger)); }
+.category-progress-row__bar-fill--neutral { background: var(--entry-color); }
+
+.category-progress-row__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 0.35rem;
+  min-width: 4rem;
+}
+
+.category-progress-row__meta strong {
+  font-size: 0.92rem;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.category-progress-row__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+}
+
+.category-progress-row__chip--positive {
+  color: var(--status-positive, var(--insights-success));
+  background: var(--status-positive-soft);
+  border-color: var(--status-positive-border);
+}
+
+.category-progress-row__chip--caution {
+  color: var(--status-watch, var(--insights-caution));
+  background: var(--status-watch-soft);
+  border-color: var(--status-watch-border);
+}
+
+.category-progress-row__chip--warning {
+  color: var(--status-near, var(--insights-warning));
+  background: var(--status-near-soft);
+  border-color: var(--status-near-border);
+}
+
+.category-progress-row__chip--danger {
+  color: var(--status-over, var(--insights-danger));
+  background: var(--status-over-soft);
+  border-color: var(--status-over-border);
+}
+
+.category-progress-row--over {
+  border-color: var(--status-over-border);
+  background: linear-gradient(180deg, var(--status-over-soft), var(--surface-panel));
+}
+
+.category-progress-row--caution {
+  border-color: var(--status-watch-border);
+  background: linear-gradient(180deg, var(--status-watch-soft), var(--surface-panel));
+}
+
+.category-progress-row--warning {
+  border-color: var(--status-near-border);
+  background: linear-gradient(180deg, var(--status-near-soft), var(--surface-panel));
+}
+
+.category-progress-row--danger {
+  border-color: var(--status-over-border);
+  background: linear-gradient(180deg, var(--status-over-soft), var(--surface-panel));
+}
+
+html[data-theme='dark'] .category-progress-row--caution {
+  background: linear-gradient(180deg, var(--status-watch-soft), rgba(255, 255, 255, 0.03));
+}
+
+html[data-theme='dark'] .category-progress-row--warning {
+  background: linear-gradient(180deg, var(--status-near-soft), rgba(255, 255, 255, 0.03));
+}
+
+html[data-theme='dark'] .category-progress-row {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+html[data-theme='dark'] .category-progress-row.category-progress-row--caution {
+  background: linear-gradient(180deg, var(--status-watch-soft), rgba(255, 255, 255, 0.03));
+}
+
+html[data-theme='dark'] .category-progress-row.category-progress-row--warning {
+  background: linear-gradient(180deg, var(--status-near-soft), rgba(255, 255, 255, 0.03));
+}
+
+html[data-theme='dark'] .category-progress-row__bar {
+  background: rgba(255, 255, 255, 0.07);
+}
+
+html[data-theme='dark'] .category-progress-row--over {
+  background: linear-gradient(180deg, var(--status-over-soft), rgba(255, 255, 255, 0.03));
+}
+
+html[data-theme='dark'] .category-progress-row--danger {
+  background: linear-gradient(180deg, var(--status-over-soft), rgba(255, 255, 255, 0.03));
+}
+
+@media (max-width: 560px) {
+  .category-progress-row {
+    grid-template-columns: minmax(0, 1.1fr) auto;
+    grid-template-areas:
+      'main meta'
+      'bar bar';
+    gap: 0.55rem 0.75rem;
+  }
+  .category-progress-row__main { grid-area: main; }
+  .category-progress-row__meta { grid-area: meta; }
+  .category-progress-row__bar { grid-area: bar; }
+}
+
+/* Hide the legacy budget-glance ring strip on the dashboard now that rows replace it */
+.dashboard-screen .budget-glance-scroll,
+.dashboard-screen .budget-glance { display: none; }
+
+/* --------------------------------------------------------------------
+   Dashboard Month pacing (trend chart card)
+   -------------------------------------------------------------------- */
+
+.dashboard-trend {
+  margin-top: 0.25rem;
+}
+
+.trend-chart-card {
+  position: relative;
+  gap: 0.75rem;
+  padding: 1.2rem 1.25rem 1rem;
+}
+
+.trend-chart-card--over {
+  border-color: rgba(183, 95, 103, 0.32);
+}
+
+.trend-chart-card .trend-chart {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.trend-chart-card .trend-chart:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 4px;
+  border-radius: 14px;
+}
+
+.trend-chart__budget-line {
+  stroke: color-mix(in srgb, var(--text-secondary) 72%, var(--text-primary) 28%);
+  stroke-width: 1.25;
+  stroke-dasharray: 1 0;
+  opacity: 0.5;
+}
+
+.trend-chart__pace-line {
+  stroke: color-mix(in srgb, var(--text-secondary) 50%, var(--text-tertiary) 50%);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 4;
+  stroke-linecap: round;
+  opacity: 0.55;
+}
+
+.trend-chart__budget-line-label {
+  font-size: 9px;
+  font-weight: 700;
+  fill: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
+.trend-chart__axis-label,
+.trend-chart__x-label {
+  font-size: 10px;
+  font-weight: 600;
+  fill: var(--text-secondary);
+  letter-spacing: 0.04em;
+}
+
+.trend-chart-card .trend-chart__line {
+  stroke: var(--accent-strong);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.trend-chart-card .trend-chart__point {
+  fill: var(--accent-strong);
+  stroke: var(--surface-panel-strong);
+  stroke-width: 2.5;
+  transition: r 160ms ease, filter 160ms ease;
+}
+
+.trend-chart-card--focused .trend-chart__point {
+  filter: drop-shadow(0 0 10px rgba(122, 181, 146, 0.55));
+  r: 6;
+}
+
+.trend-chart-card .trend-chart__point--warning {
+  fill: var(--danger, #b75f67);
+}
+
+.trend-chart-card__callout {
+  position: absolute;
+  transform: translate(-50%, -140%);
+  padding: 0.35rem 0.65rem;
+  border-radius: 12px;
+  background: var(--surface-floating, var(--surface-panel-strong));
+  border: 1px solid var(--divider-soft);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.1rem;
+  text-align: center;
+  pointer-events: none;
+  font-size: 0.78rem;
+}
+
+.trend-chart-card__callout strong {
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.trend-chart-card__callout small {
+  color: var(--text-secondary);
+}
+
+.trend-chart-card__legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-top: 0.65rem;
+  margin: 0;
+  border-top: 1px solid var(--divider-soft);
+}
+
+.trend-chart-card__legend-item {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.trend-chart-card__legend-item dt {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+  position: relative;
+  padding-left: 14px;
+}
+
+.trend-chart-card__legend-item dt::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 10px;
+  height: 2px;
+  border-radius: 2px;
+  transform: translateY(-50%);
+}
+
+.trend-chart-card__legend-item--actual dt::before { background: var(--accent-strong); }
+.trend-chart-card__legend-item--pace dt::before { background: var(--accent-strong); opacity: 0.55; }
+.trend-chart-card__legend-item--budget dt::before { background: var(--text-secondary); opacity: 0.55; }
+
+.trend-chart-card__legend-item dd {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+html[data-theme='dark'] .trend-chart-card__callout {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* --------------------------------------------------------------------
+   Dashboard activity filter + unified activity layout
+   -------------------------------------------------------------------- */
+
+.dashboard-activity-filter {
+  margin-bottom: 0.65rem;
+}
+
+.dashboard-grid .dashboard-panel--activity {
+  min-width: 0;
+}
+
+.activity-feed__row:focus-within {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 2px;
+  border-radius: 14px;
+}
+
+.activity-feed__row--income .entry-amount {
+  color: var(--success, var(--accent-strong));
+}
+
+/* --------------------------------------------------------------------
+   CashFlowSnapshot (dashboard right column)
+   -------------------------------------------------------------------- */
+
+.cashflow-snapshot {
+  grid-column: auto;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.42rem;
+  padding: 0.95rem 1.1rem 1rem;
+  align-self: stretch;
+}
+
+.cashflow-snapshot__header {
+  flex: 0 0 auto;
+}
+
+.cashflow-snapshot__bars {
+  display: grid;
+  gap: 0.28rem;
+  flex: 0 0 auto;
+}
+
+.cashflow-snapshot__row {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.cashflow-snapshot__row-label {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.cashflow-snapshot__row-bar {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(122, 136, 127, 0.1);
+  overflow: hidden;
+}
+
+.cashflow-snapshot__row-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  transition: width 420ms ease;
+}
+
+.cashflow-snapshot__row-fill--income {
+  background: var(--success, var(--accent));
+}
+
+.cashflow-snapshot__row-fill--expense {
+  background: var(--danger, #b75f67);
+  opacity: 0.85;
+}
+
+.cashflow-snapshot__row-value {
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.cashflow-snapshot__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.cashflow-snapshot__summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding-top: 0.28rem;
+  margin-top: 0.1rem;
+  border-top: 1px solid var(--divider-soft);
+  flex: 0 0 auto;
+}
+
+.cashflow-snapshot__net,
+.cashflow-snapshot__savings {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.cashflow-snapshot__net span,
+.cashflow-snapshot__savings span {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.cashflow-snapshot__net strong,
+.cashflow-snapshot__savings strong {
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+}
+
+.cashflow-snapshot__net--positive strong { color: var(--success, var(--accent-strong)); }
+.cashflow-snapshot__net--danger strong { color: var(--danger, #b75f67); }
+.cashflow-snapshot__net--neutral strong { color: var(--text-primary); }
+
+html[data-theme='dark'] .cashflow-snapshot__row-bar {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 560px) {
+  .cashflow-snapshot__row {
+    grid-template-columns: 72px minmax(0, 1fr) auto;
+    gap: 0.55rem;
+  }
+}
+
+/* --------------------------------------------------------------------
+   Insights Â hide the old sparkline block, strengthen cashflow chart
+   -------------------------------------------------------------------- */
+
+.insights-screen--issue57 .insights-v57__spend-pattern,
+.insights-screen--issue57 .insights-v57__sparkline,
+.insights-screen--issue57 .insights-v57__cashflow-summary,
+.insights-screen--issue57 .insights-v57__top-expense-meter,
+.insights-screen--issue57 .insights-v57__top-expense-meter-head {
+  display: none;
+}
+
+.insights-screen--issue57 .insights-v57__top-grid {
+  align-items: stretch;
+}
+
+.insights-screen--issue57 .insights-v57__hero-body--donut-only {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.insights-screen--issue57 .insights-v57__hero-body--donut-only .insights-v57__category-grid {
+  display: none;
+}
+
+.insights-screen--issue57 .insights-v57__category-grid {
+  display: none;
+}
+
+/* Cash-flow bar colors match the legend swatches (#7cb38b income / #6879df expense)
+   defined earlier in this file. We do not override them here; instead we lift contrast
+   slightly in dark mode so both bars remain legible. */
+
+html[data-theme='dark'] .insights-screen--issue57 .insights-v57__cashflow-bar--income {
+  fill: #93c8a3;
+}
+
+html[data-theme='dark'] .insights-screen--issue57 .insights-v57__cashflow-bar--expense {
+  fill: #8693e6;
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-peak-label {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.15rem 0.4rem;
+  border-radius: 8px;
+  background: var(--surface-floating, var(--surface-panel-strong));
+  border: 1px solid var(--divider-soft);
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-column {
+  position: relative;
+}
+
+.insights-screen--issue57 .insights-v57__detail-section,
+.insights-screen--issue57 .insights-v57__pace-section,
+.insights-screen--issue57 .insights-v57__top-expense-section {
+  margin-top: 0.25rem;
+}
+
+.insights-screen--issue57 .category-progress-list--insights .category-progress-row {
+  border-radius: 1.1rem;
+}
+
+.insights-screen--issue57 .insights-v57__pace-card {
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--divider-soft);
+  border-radius: 1.4rem;
+  background: var(--surface-panel);
+}
+
+html[data-theme='dark'] .insights-screen--issue57 .insights-v57__pace-card {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* --------------------------------------------------------------------
+   PaceVsLastMonthChart
+   -------------------------------------------------------------------- */
+
+.pace-chart {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.pace-chart--empty {
+  text-align: center;
+  padding: 1.6rem 1rem;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.pace-chart--empty strong {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.pace-chart__legend {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.pace-chart__legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.pace-chart__swatch {
+  display: inline-block;
+  width: 14px;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.pace-chart__swatch--current { background: var(--accent-strong); }
+.pace-chart__swatch--previous { background: var(--text-secondary); opacity: 0.6; }
+
+.pace-chart__default-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.85rem;
+  margin: 0;
+  padding: 0.55rem 0.7rem;
+  border-radius: 12px;
+  border: 1px solid var(--divider-soft);
+  background: color-mix(in srgb, var(--surface-panel-strong) 92%, var(--accent-strong) 8%);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.pace-chart__default-day {
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.pace-chart__default-current strong {
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.pace-chart__default-delta--ahead { color: var(--warning, #c9825a); font-weight: 700; }
+.pace-chart__default-delta--behind { color: var(--success, var(--accent-strong)); font-weight: 700; }
+.pace-chart__default-delta--even { color: var(--text-primary); font-weight: 600; }
+
+.pace-chart__baseline {
+  stroke: var(--divider-soft);
+  stroke-width: 1;
+}
+
+.pace-chart__line--current {
+  stroke: var(--accent-strong);
+  stroke-width: 2.5;
+  fill: none;
+  stroke-linecap: round;
+}
+
+.pace-chart__line--current-positive { stroke: var(--status-positive, var(--accent-strong)); }
+.pace-chart__line--current-warning { stroke: var(--status-watch, var(--warning)); }
+
+.pace-chart__line--previous {
+  stroke: var(--text-secondary);
+  stroke-width: 2;
+  fill: none;
+  stroke-linecap: round;
+  stroke-dasharray: 4 4;
+  opacity: 0.6;
+}
+
+.pace-chart__divider {
+  stroke: var(--text-secondary);
+  stroke-width: 1;
+  stroke-dasharray: 2 4;
+  opacity: 0.45;
+}
+
+.pace-chart__point--current {
+  fill: var(--accent-strong);
+  stroke: var(--surface-panel-strong);
+  stroke-width: 2.5;
+}
+
+.pace-chart__point--previous {
+  fill: var(--text-secondary);
+  stroke: var(--surface-panel-strong);
+  stroke-width: 2.5;
+  opacity: 0.55;
+}
+
+.pace-chart__readout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.65rem;
+  margin: 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--divider-soft);
+}
+
+.pace-chart__readout-item {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.pace-chart__readout-item dt {
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.pace-chart__readout-item dd {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.pace-chart__readout-item--ahead dd { color: var(--warning, #c9825a); }
+.pace-chart__readout-item--behind dd { color: var(--success, var(--accent-strong)); }
+.pace-chart__readout-item--even dd { color: var(--text-primary); }
+
+/* --------------------------------------------------------------------
+   Transactions polish
+   -------------------------------------------------------------------- */
+
+.transactions-screen .search-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+@media (max-width: 640px) {
+  .transactions-screen .search-panel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .transactions-screen .search-panel .segment-control {
+    width: 100%;
+  }
+}
+
+.transactions-screen .transaction-item {
+  position: relative;
+  transition: background 160ms ease, transform 160ms ease, border-color 160ms ease;
+}
+
+.transactions-screen .transaction-item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 10%;
+  bottom: 10%;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--entry-color);
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.transactions-screen .transaction-item:hover {
+  background: var(--surface-panel-strong);
+}
+
+.transactions-screen .transaction-item:hover::before,
+.transactions-screen .transaction-item:focus-visible::before {
+  opacity: 0.9;
+}
+
+.transactions-screen .transaction-item:focus-visible {
+  outline: 2px solid var(--accent-soft);
+  outline-offset: 2px;
+  border-radius: 14px;
+}
+
+.detail-sheet--expense .detail-sheet__tone-band {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--entry-color), transparent 80%);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.detail-sheet--income .detail-sheet__tone-band {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--success, var(--accent)), transparent 80%);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.detail-sheet__hero {
+  position: relative;
+}
+
+/* --------------------------------------------------------------------
+   Mobile polish Â dashboard hero spacing and trend card
+   -------------------------------------------------------------------- */
+
+@media (max-width: 560px) {
+  .dashboard-screen .budget-hero {
+    padding: 1.1rem 1.1rem 1rem;
+  }
+
+  .trend-chart-card {
+    padding: 1rem 1rem 0.85rem;
+  }
+
+  .trend-chart-card__legend {
+    gap: 0.45rem;
+  }
+}
+
+@media (max-width: 880px) {
+  .dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .dashboard-grid .cashflow-snapshot {
+    margin-top: 0.25rem;
+  }
+}
+
+/* --------------------------------------------------------------------
+   Issue #59 second pass Â interactive charts, drill-down modal,
+   compact pressure tile, and audit fixes
+   -------------------------------------------------------------------- */
+
+/* MonthPacingChart layout (replaces the earlier trend-chart-card visuals) */
+.month-pacing {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1rem 1.1rem 0.85rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--divider-soft);
+  background: linear-gradient(180deg, var(--surface-panel-strong), var(--surface-panel));
+  box-shadow: var(--shadow-card);
+}
+
+.month-pacing--over { border-color: rgba(183, 95, 103, 0.32); }
+
+.month-pacing__frame {
+  position: relative;
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: stretch;
+  padding-left: 0.35rem;
+}
+
+.month-pacing__y-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-right: 0.6rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary, var(--text-secondary));
+  border-right: 1px solid var(--divider-soft);
+  min-height: 168px;
+  padding-top: 4px;
+  padding-bottom: 22px;
+}
+
+.month-pacing__y-axis-cap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.08rem;
+  line-height: 1.15;
+  text-align: right;
+}
+
+.month-pacing__y-axis-cap-label {
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+  opacity: 0.9;
+}
+
+.month-pacing__y-axis-cap-value {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+}
+
+.month-pacing__plot {
+  position: relative;
+  min-width: 0;
+  min-height: 168px;
+}
+
+.month-pacing__svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+}
+
+.month-pacing__svg:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 4px;
+  border-radius: 12px;
+}
+
+.month-pacing__line {
+  stroke: var(--accent-strong);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.month-pacing__line--positive { stroke: var(--success, var(--accent-strong)); }
+.month-pacing__line--warning { stroke: var(--watch-amber, #c9a227); }
+.month-pacing__line--danger { stroke: var(--danger, #b75f67); }
+.month-pacing__line--neutral { stroke: var(--accent-strong); }
+
+.month-pacing__guide {
+  stroke: var(--text-secondary);
+  stroke-width: 1;
+  stroke-dasharray: 1 5;
+  stroke-linecap: round;
+  opacity: 0.32;
+  pointer-events: none;
+}
+
+.month-pacing__point {
+  fill: var(--accent-strong);
+  stroke: var(--surface-panel-strong);
+  stroke-width: 2.5;
+  transition: filter 160ms ease;
+}
+
+.month-pacing--inspecting .month-pacing__point {
+  filter: drop-shadow(0 0 8px rgba(122, 181, 146, 0.55));
+}
+
+.month-pacing__point--warning {
+  fill: var(--danger, #b75f67);
+}
+
+.month-pacing__snapshot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.75rem;
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-panel-strong) 88%, var(--accent-strong) 12%);
+  border: 1px solid color-mix(in srgb, var(--divider-soft) 85%, var(--accent-strong) 15%);
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.month-pacing__snapshot-label {
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.month-pacing__snapshot-actual strong {
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+
+.month-pacing__snapshot-pace em {
+  font-style: normal;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.month-pacing__callout {
+  position: absolute;
+  display: grid;
+  gap: 0.05rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 12px;
+  background: var(--surface-floating, var(--surface-panel-strong));
+  border: 1px solid var(--divider-soft);
+  box-shadow: var(--shadow-card);
+  font-size: 0.78rem;
+  text-align: center;
+  pointer-events: none;
+  min-width: 88px;
+  z-index: 2;
+}
+
+.month-pacing__callout--below {
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.month-pacing__callout-day {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.month-pacing__callout-value {
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.month-pacing__callout-delta {
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+}
+
+.month-pacing__callout--warning .month-pacing__callout-delta { color: var(--warning, #c9825a); }
+.month-pacing__callout--danger .month-pacing__callout-delta { color: var(--danger, #b75f67); font-weight: 700; }
+.month-pacing__callout--positive .month-pacing__callout-delta { color: var(--success, var(--accent-strong)); }
+
+.month-pacing__x-axis {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 0 0 56px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.month-pacing__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem 1.25rem;
+  margin: 0;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--divider-soft);
+}
+
+.month-pacing__legend-item {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.month-pacing__legend-item dt {
+  position: relative;
+  padding-left: 14px;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.month-pacing__legend-item dt::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 12px;
+  height: 3px;
+  border-radius: 2px;
+  transform: translateY(-50%);
+  box-sizing: border-box;
+}
+
+.month-pacing__legend-item--actual dt::before {
+  background: var(--accent-strong);
+}
+
+.month-pacing--spend-positive .month-pacing__legend-item--actual dt::before { background: var(--success, var(--accent-strong)); }
+.month-pacing--spend-warning .month-pacing__legend-item--actual dt::before { background: var(--watch-amber, #c9a227); }
+.month-pacing--spend-danger .month-pacing__legend-item--actual dt::before { background: var(--danger, #b75f67); }
+
+.month-pacing__legend-item--pace dt {
+  padding-left: 22px;
+}
+
+.month-pacing__legend-item--pace dt::before {
+  top: 50%;
+  width: 20px;
+  height: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  border-bottom: 2.5px dashed color-mix(in srgb, var(--text-secondary) 50%, var(--text-tertiary) 50%);
+  opacity: 0.55;
+}
+
+.month-pacing__legend-item--budget dt::before {
+  width: 14px;
+  height: 2.5px;
+  background: color-mix(in srgb, var(--text-secondary) 72%, var(--text-primary) 28%);
+  border: 0;
+  border-radius: 2px;
+  opacity: 0.65;
+}
+
+.month-pacing__legend-item--delta dt::before { display: none; }
+.month-pacing__legend-item--delta dt { padding-left: 0; }
+
+.month-pacing__legend-item dd {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.month-pacing__legend-item--over dd { color: var(--warning, #c9825a); }
+.month-pacing__legend-item--under dd { color: var(--success, var(--accent-strong)); }
+
+html[data-theme='dark'] .month-pacing__y-axis,
+html[data-theme='dark'] .month-pacing__x-axis {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 560px) {
+  .month-pacing__frame { grid-template-columns: 44px minmax(0, 1fr); }
+  .month-pacing__y-axis { font-size: 0.66rem; }
+  .month-pacing__x-axis { padding-left: 48px; font-size: 0.66rem; }
+  .month-pacing__legend { gap: 0.55rem 0.85rem; }
+  .month-pacing__callout { min-width: 78px; font-size: 0.74rem; }
+}
+
+/* --------------------------------------------------------------------
+   AllocationBar marker label
+   -------------------------------------------------------------------- */
+
+.allocation-bar { position: relative; margin-bottom: 1.2rem; }
+
+.allocation-bar__marker-label {
+  position: absolute;
+  bottom: -1.4rem;
+  transform: translateX(-50%);
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(122, 136, 127, 0.14);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+html[data-theme='dark'] .allocation-bar__marker-label {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.78);
+}
+
+/* --------------------------------------------------------------------
+   CategoryProgressRow Â interactive variant + stronger over-budget
+   -------------------------------------------------------------------- */
+
+.category-progress-row--interactive {
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  width: 100%;
+  appearance: none;
+}
+
+.category-progress-row--interactive:hover {
+  border-color: rgba(122, 181, 146, 0.4);
+  transform: translateY(-1px);
+}
+
+.category-progress-row--interactive:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.category-progress-row--over {
+  border-color: var(--status-over-border);
+  background: linear-gradient(180deg, var(--status-over-soft), var(--surface-panel));
+}
+
+.category-progress-row--over .category-progress-row__bar-fill {
+  box-shadow: inset 0 0 0 1px rgba(183, 95, 103, 0.5);
+}
+
+/* --------------------------------------------------------------------
+   PaceVsLastMonthChart Â interactive callout
+   -------------------------------------------------------------------- */
+
+.pace-chart__plot {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 320 / 156;
+  min-height: 0;
+}
+
+.pace-chart__svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+}
+
+.pace-chart__svg:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 4px;
+  border-radius: 12px;
+}
+
+.pace-chart__guide {
+  stroke: var(--accent-strong);
+  stroke-width: 1;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.pace-chart__today-divider {
+  stroke: var(--text-secondary);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+  opacity: 0.55;
+}
+
+.pace-chart__callout {
+  position: absolute;
+  display: grid;
+  gap: 0.1rem;
+  padding: 0.45rem 0.7rem;
+  border-radius: 12px;
+  background: var(--surface-floating, var(--surface-panel-strong));
+  border: 1px solid var(--divider-soft);
+  box-shadow: var(--shadow-card);
+  font-size: 0.78rem;
+  text-align: center;
+  pointer-events: none;
+  min-width: 132px;
+  z-index: 2;
+}
+
+.pace-chart__callout--below {
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.1);
+}
+
+.pace-chart__callout-day {
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.pace-chart__callout-current {
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+.pace-chart__callout-previous {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.pace-chart__callout-delta {
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
+.pace-chart__callout--ahead .pace-chart__callout-delta { color: var(--warning, #c9825a); }
+.pace-chart__callout--behind .pace-chart__callout-delta { color: var(--success, var(--accent-strong)); }
+.pace-chart__callout--even .pace-chart__callout-delta { color: var(--text-secondary); }
+
+.pace-chart__x-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+/* --------------------------------------------------------------------
+   CashFlowSnapshot Â interactive trend
+   -------------------------------------------------------------------- */
+
+.cashflow-snapshot__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.cashflow-snapshot__headings {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.cashflow-snapshot__heading {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+}
+
+.cashflow-snapshot__period {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text-secondary);
+}
+
+.cashflow-snapshot__header .section-link:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 3px;
+  border-radius: 8px;
+}
+
+.cashflow-snapshot__trend {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.28rem;
+  padding-top: 0.32rem;
+  margin-top: auto;
+  border-top: 1px solid var(--divider-soft);
+  flex: 1 1 auto;
+  min-height: 0;
+  justify-content: flex-end;
+}
+
+.cashflow-snapshot__trend-caption {
+  margin: 0;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.cashflow-snapshot__trend-bars {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.45rem;
+  min-height: 100px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.35rem 0 0.2rem;
+}
+
+.cashflow-snapshot__trend-col {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  align-items: end;
+  justify-items: center;
+  gap: 0.2rem;
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: background 160ms ease;
+}
+
+.cashflow-snapshot__trend-col:hover,
+.cashflow-snapshot__trend-col--focused {
+  background: rgba(122, 181, 146, 0.1);
+}
+
+.cashflow-snapshot__trend-col:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.cashflow-snapshot__trend-bar-wrap {
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+}
+
+.cashflow-snapshot__trend-bar {
+  display: block;
+  width: 100%;
+  max-width: 40px;
+  min-height: 4px;
+  border-radius: 8px 8px 4px 4px;
+  transition: height 420ms ease;
+}
+
+.cashflow-snapshot__trend-bar--positive { background: var(--success, var(--accent)); }
+.cashflow-snapshot__trend-bar--danger { background: var(--danger, #b75f67); opacity: 0.85; }
+
+.cashflow-snapshot__trend-col small {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.cashflow-snapshot__trend-readout {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.35rem;
+  padding: 0.2rem 0 0;
+  border-left: 0;
+  min-width: 0;
+}
+
+.cashflow-snapshot__trend-readout-main {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.cashflow-snapshot__trend-readout-main > span {
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.cashflow-snapshot__trend-readout-main > strong {
+  font-size: 1.12rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  flex: 0 0 auto;
+}
+
+.cashflow-snapshot__trend-readout-detail {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.3;
+  justify-content: space-between;
+}
+
+.cashflow-snapshot__period-hint {
+  font-weight: 600;
+  font-size: 0.82rem;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.cashflow-snapshot__trend-readout--positive .cashflow-snapshot__trend-readout-main > strong { color: var(--success, var(--accent-strong)); }
+.cashflow-snapshot__trend-readout--danger .cashflow-snapshot__trend-readout-main > strong { color: var(--danger, #b75f67); }
+.cashflow-snapshot__trend-readout--neutral .cashflow-snapshot__trend-readout-main > strong { color: var(--text-primary); }
+
+@media (max-width: 560px) {
+  .cashflow-snapshot__trend {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .cashflow-snapshot__trend-readout {
+    border-left: 0;
+    border-top: 1px solid var(--divider-soft);
+    padding: 0.5rem 0 0;
+  }
+}
+
+/* --------------------------------------------------------------------
+   CategoryTransactionsModal
+   -------------------------------------------------------------------- */
+
+.category-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(15, 24, 19, 0.42);
+  backdrop-filter: blur(2px);
+  z-index: 60;
+  animation: category-modal-fade 240ms ease both;
+}
+
+.category-modal-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.category-modal {
+  position: relative;
+  display: grid;
+  gap: 0.85rem;
+  width: min(560px, calc(100vw - 2rem));
+  max-height: calc(100vh - 2rem);
+  padding: 1.4rem 1.5rem;
+  border-radius: 1.6rem;
+  background: var(--surface-panel-strong);
+  box-shadow: var(--shadow-app, 0 30px 80px rgba(0, 0, 0, 0.18));
+  overflow: hidden;
+  z-index: 1;
+  animation: category-modal-pop 320ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+@keyframes category-modal-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes category-modal-pop {
+  from {
+    opacity: 0;
+    transform: translateY(10px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.category-modal--compare {
+  width: min(820px, calc(100vw - 2rem));
+}
+
+.category-modal__header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.category-modal__header-icon {
+  display: grid;
+  place-items: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: var(--entry-soft);
+  color: var(--entry-color);
+  font-size: 1.25rem;
+}
+
+.category-modal__header-copy {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.category-modal__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.category-modal__title {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+}
+
+.category-modal__subtitle {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.category-modal__close {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--divider-soft);
+  background: transparent;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.category-modal__close:hover {
+  background: var(--surface-panel);
+  color: var(--text-primary);
+}
+
+.category-modal__close:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.category-modal__totals {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--divider-soft);
+  border-radius: 1rem;
+  background: var(--surface-panel);
+}
+
+.category-modal__totals dt {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.category-modal__totals dd {
+  margin: 0.05rem 0 0;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.category-modal__totals-delta--danger dd { color: var(--danger, #b75f67); }
+.category-modal__totals-delta--positive dd { color: var(--success, var(--accent-strong)); }
+
+.category-modal__compare {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.category-modal__column {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.category-modal__column-heading {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary, var(--text-secondary));
+}
+
+.category-modal__list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.category-modal__row {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.7rem;
+  border-radius: 0.85rem;
+  background: var(--surface-panel);
+  border: 1px solid var(--divider-soft);
+}
+
+.category-modal__row-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  font-size: 0.95rem;
+}
+
+.category-modal__row-copy {
+  display: grid;
+  gap: 0.05rem;
+  min-width: 0;
+}
+
+.category-modal__row-copy strong {
+  font-size: 0.92rem;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category-modal__row-copy span {
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+}
+
+.category-modal__row-amount {
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+  font-weight: 700;
+}
+
+.category-modal__empty {
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .category-modal__compare {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+html[data-theme='dark'] .category-modal {
+  background: rgba(20, 28, 24, 0.96);
+}
+
+html[data-theme='dark'] .category-modal__row {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+/* --------------------------------------------------------------------
+   Insights Â interactive movers + tighter rhythm + ribbon peak
+   -------------------------------------------------------------------- */
+
+.insights-screen--issue57 .insights-v57__mover-row--interactive {
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  width: 100%;
+  appearance: none;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.insights-screen--issue57 .insights-v57__mover-row--interactive:hover {
+  border-color: rgba(122, 181, 146, 0.4);
+  transform: translateY(-1px);
+}
+
+.insights-screen--issue57 .insights-v57__mover-row--interactive:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-ribbon-item--peak {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 0.05rem;
+}
+
+.insights-screen--issue57 .insights-v57__rhythm-ribbon-item--peak small {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+/* Tighten the rhythm card so the empty space below the chart shrinks */
+.insights-screen--issue57 .insights-v57__rhythm-stage {
+  min-height: 9rem;
+  padding-bottom: 0.55rem;
+}
+
+@media (max-width: 720px) {
+  .insights-screen--issue57 .insights-v57__rhythm-stage {
+    min-height: 7rem;
+  }
+}
+
+/* --------------------------------------------------------------------
+   Insights – interactive top expense rows
+   -------------------------------------------------------------------- */
+
+.insights-screen--issue57 .insights-v57__top-expense-row--interactive {
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  width: 100%;
+  appearance: none;
+  background: var(--insights-fill-veil, var(--surface-panel));
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.insights-screen--issue57 .insights-v57__top-expense-row--interactive:hover {
+  border-color: rgba(122, 181, 146, 0.4);
+  transform: translateY(-1px);
+}
+
+.insights-screen--issue57 .insights-v57__top-expense-row--interactive:focus-visible {
+  outline: 2px solid var(--accent-strong);
+  outline-offset: 2px;
+}

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -11,11 +11,14 @@ import {
   demoBudgetSummary,
   demoBudgetTrend,
   demoCategoryBudgets,
+  demoInsightsSnapshot,
 } from '@/lib/demoData'
 import { getCategoryVisual, getEntryVisual, getInitialsLabel } from '@/lib/financeVisuals'
 import {
   buildActivityFeed,
+  buildDailySpendDetailsFromExpenses,
   buildMonthlySpendTrend,
+  buildRecentCashFlow,
   formatCurrency,
   formatMonthPeriod,
   formatShortDate,
@@ -29,11 +32,17 @@ import {
   buildOverallBudgetHealth as buildSharedOverallBudgetHealth,
   getMonthProgressState as getSharedMonthProgressState,
 } from '@/lib/budgetHealth'
-const PREVIEW_LIMIT = 4
-const INCOME_LIMIT = 4
-const CHART_WIDTH = 312
-const CHART_HEIGHT = 148
-const CHART_INSET = 18
+import AllocationBar from '@/components/ui/AllocationBar'
+import BudgetHudMetrics from '@/components/ui/BudgetHudMetrics'
+import CashFlowSnapshot from '@/components/ui/CashFlowSnapshot'
+import CategoryProgressRow from '@/components/ui/CategoryProgressRow'
+import CategoryTransactionsModal from '@/components/ui/CategoryTransactionsModal'
+import FinancialHealthTile from '@/components/ui/FinancialHealthTile'
+import MonthPacingChart from '@/components/ui/MonthPacingChart'
+import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
+
+const ACTIVITY_PREVIEW_LIMIT = 6
+const CATEGORY_PREVIEW_LIMIT = 5
 
 function getErrorMessage(error) {
   if (error instanceof ApiError) return error.message
@@ -164,90 +173,6 @@ export function getBudgetHudModel(summary, { month, observedDayCount = 0, refere
   }
 }
 
-function getMonthShape(month) {
-  const monthDate = new Date(`${month}T12:00:00Z`)
-  if (Number.isNaN(monthDate.getTime())) return null
-
-  const year = monthDate.getUTCFullYear()
-  const monthIndex = monthDate.getUTCMonth()
-  return {
-    monthLength: new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate(),
-  }
-}
-
-function buildProjectedTrend(month, budget, pointCount) {
-  const monthShape = getMonthShape(month)
-  if (!monthShape || !budget || pointCount < 1) return []
-
-  return Array.from({ length: pointCount }, (_, index) => Number((
-    budget * ((index + 1) / monthShape.monthLength)
-  ).toFixed(2)))
-}
-
-function getTrendCeiling(points, projectedPoints = [], budget = 0) {
-  const referencePoints = [...points, ...projectedPoints].filter((point) => Number.isFinite(point))
-  if (!referencePoints.length) return 1
-
-  const maxPoint = Math.max(...referencePoints)
-  if (budget > 0) {
-    return Math.max(maxPoint * 1.14, maxPoint + 120)
-  }
-
-  return Math.max(maxPoint * 1.18, maxPoint + 120)
-}
-
-function buildTrendPath(points, width, height, inset, maxValue) {
-  if (!points.length) return ''
-
-  const safeMax = maxValue > 0 ? maxValue : 1
-
-  return points
-    .map((point, index) => {
-      const x = inset + ((width - inset * 2) / Math.max(points.length - 1, 1)) * index
-      const y = height - inset - ((height - inset * 2) * point) / safeMax
-      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
-    })
-    .join(' ')
-}
-
-function buildAreaPath(points, width, height, inset, maxValue) {
-  if (!points.length) return ''
-
-  const linePath = buildTrendPath(points, width, height, inset, maxValue)
-  const baseline = height - inset
-  return `${linePath} L ${width - inset} ${baseline} L ${inset} ${baseline} Z`
-}
-
-function buildComparisonAreaPath(topPoints, bottomPoints, width, height, inset, maxValue) {
-  if (!topPoints.length || topPoints.length !== bottomPoints.length) return ''
-
-  const safeMax = maxValue > 0 ? maxValue : 1
-  const buildPoint = (point, index) => {
-    const x = inset + ((width - inset * 2) / Math.max(topPoints.length - 1, 1)) * index
-    const y = height - inset - ((height - inset * 2) * point) / safeMax
-    return `${x.toFixed(2)} ${y.toFixed(2)}`
-  }
-
-  const topPath = topPoints.map((point, index) => `${index === 0 ? 'M' : 'L'} ${buildPoint(point, index)}`).join(' ')
-  const bottomPath = bottomPoints
-    .map((point, index) => ({ point, index }))
-    .reverse()
-    .map(({ point, index }) => `L ${buildPoint(point, index)}`)
-    .join(' ')
-
-  return `${topPath} ${bottomPath} Z`
-}
-
-function getTrendPoint(points, width, height, inset, maxValue, index = points.length - 1) {
-  if (!points.length || index < 0 || index >= points.length) return null
-
-  const safeMax = maxValue > 0 ? maxValue : 1
-  return {
-    x: inset + ((width - inset * 2) / Math.max(points.length - 1, 1)) * index,
-    y: height - inset - ((height - inset * 2) * points[index]) / safeMax,
-  }
-}
-
 function buildLiveCategoryCards(categoryStatuses = []) {
   return categoryStatuses.map((item) => {
     const displayName = item.category_name || 'Uncategorized'
@@ -267,6 +192,8 @@ function buildLiveCategoryCards(categoryStatuses = []) {
       soft: visual.soft,
       progress: categoryHealth.progressPercentage,
       amount,
+      monthlyLimit: Number(item.monthly_limit ?? 0) > 0 ? Number(item.monthly_limit) : null,
+      remainingAmount: categoryHealth.remainingAmount,
       note: categoryHealth.remainingText,
       statusLabel: categoryHealth.label,
       statusTone: categoryHealth.tone,
@@ -316,6 +243,8 @@ export function buildDerivedCategoryCards(expenses = []) {
       soft: visual.soft,
       progress: Math.min(share, 100),
       amount,
+      monthlyLimit: null,
+      remainingAmount: null,
       note: `${Math.round(share) || 0}% of spend`,
     }
   })
@@ -334,7 +263,11 @@ export function getBudgetPressureHighlight(summary, expenses = [], derivedCatego
 
   return buildSharedBudgetPressureHighlight({
     categoryStatuses: summary?.category_statuses,
-    fallbackSpendCards: spendShareCards,
+    fallbackSpendCards: spendShareCards.map((card) => ({
+      name: card.name,
+      note: card.note,
+      progress: card.progress,
+    })),
   })
 }
 
@@ -372,6 +305,9 @@ export default function DashboardView() {
   const [budgetDraft, setBudgetDraft] = useState({ monthly_limit: '' })
   const [isBudgetSaving, setIsBudgetSaving] = useState(false)
   const [budgetSaveError, setBudgetSaveError] = useState('')
+  const [activityFilter, setActivityFilter] = useState('all')
+  const [categoryDrillDown, setCategoryDrillDown] = useState(null)
+  const [activityDetailEntry, setActivityDetailEntry] = useState(null)
 
   useEffect(() => {
     if (isSampleMode || !isReady || !session?.accessToken) return
@@ -451,6 +387,15 @@ export default function DashboardView() {
     return () => controller.abort()
   }, [currentMonth, dataChangedToken, isReady, isSampleMode, logout, reloadToken, router, session?.accessToken])
 
+  useEffect(() => {
+    if (!activityDetailEntry) return undefined
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setActivityDetailEntry(null)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [activityDetailEntry])
+
   const openBudgetSheet = () => {
     const currentLimit = isSampleMode
       ? demoBudgetSummary?.monthly_limit
@@ -504,11 +449,16 @@ export default function DashboardView() {
   const currentMonthExpenses = isSampleMode
     ? []
     : liveState.expenses.filter((expense) => isInMonth(expense.date || expense.created_at, currentMonth))
+  const categoryTransactionDetails = isSampleMode
+    ? (demoInsightsSnapshot?.dailySpend?.details ?? [])
+    : buildDailySpendDetailsFromExpenses(currentMonthExpenses)
   const activity = isSampleMode
     ? demoActivity
     : buildActivityFeed(liveState.expenses, liveState.income)
-  const recentActivity = activity.slice(0, PREVIEW_LIMIT)
-  const recentIncome = activity.filter((entry) => entry.kind === 'income').slice(0, INCOME_LIMIT)
+  const filteredActivity = activityFilter === 'all'
+    ? activity
+    : activity.filter((entry) => entry.kind === activityFilter)
+  const recentActivity = filteredActivity.slice(0, ACTIVITY_PREVIEW_LIMIT)
   const chartMonth = isSampleMode ? DEMO_MONTH : summary?.month || currentMonth
   const hasBudgetedStatuses = hasBudgetedCategoryStatuses(summary?.category_statuses)
   const derivedCategoryCards = !isSampleMode && !hasBudgetedStatuses
@@ -530,6 +480,8 @@ export default function DashboardView() {
         soft: visual.soft,
         progress: categoryHealth.progressPercentage,
         amount: item.spent,
+        monthlyLimit: item.budget,
+        remainingAmount: categoryHealth.remainingAmount,
         note: categoryHealth.remainingText,
         statusLabel: categoryHealth.label,
         statusTone: categoryHealth.tone,
@@ -549,25 +501,34 @@ export default function DashboardView() {
     summary,
     availability: summaryAvailability,
   })
-  const pressureHighlight = getBudgetPressureHighlight(summary, currentMonthExpenses, derivedCategoryCards)
-  const projectedTrendPoints = buildProjectedTrend(chartMonth, hudState.budget, trendPoints.length)
-  const chartCeiling = getTrendCeiling(trendPoints, projectedTrendPoints, hudState.budget)
-  const linePath = buildTrendPath(trendPoints, CHART_WIDTH, CHART_HEIGHT, CHART_INSET, chartCeiling)
-  const projectedPath = buildTrendPath(projectedTrendPoints, CHART_WIDTH, CHART_HEIGHT, CHART_INSET, chartCeiling)
-  const areaPath = buildAreaPath(trendPoints, CHART_WIDTH, CHART_HEIGHT, CHART_INSET, chartCeiling)
-  const overrunTrendPoints = trendPoints.map((point, index) => Math.max(point, projectedTrendPoints[index] ?? point))
-  const hasPaceOverrun = projectedTrendPoints.some((point, index) => trendPoints[index] > point)
-  const overrunPath = hasPaceOverrun
-    ? buildComparisonAreaPath(overrunTrendPoints, projectedTrendPoints, CHART_WIDTH, CHART_HEIGHT, CHART_INSET, chartCeiling)
-    : ''
-  const overrunAmount = projectedTrendPoints.length
-    ? Math.max((trendPoints.at(-1) ?? 0) - (projectedTrendPoints.at(-1) ?? 0), 0)
-    : 0
-  const currentPoint = getTrendPoint(trendPoints, CHART_WIDTH, CHART_HEIGHT, CHART_INSET, chartCeiling)
-  const currentPointLeft = currentPoint ? `${(currentPoint.x / CHART_WIDTH) * 100}%` : '50%'
-  const currentPointTop = currentPoint ? `${(currentPoint.y / CHART_HEIGHT) * 100}%` : '50%'
+  const recentCashFlow = isSampleMode
+    ? (() => {
+      const monthlyIncome = getSafeMoneyNumber(demoBudgetSummary?.total_income)
+      const monthlyExpenses = getSafeMoneyNumber(demoBudgetSummary?.total_expenses)
+      return [
+        { month: '2026-01-01', label: 'Jan', incomeAmount: monthlyIncome * 0.95, expenseAmount: monthlyExpenses * 0.88, netAmount: Number((monthlyIncome * 0.95 - monthlyExpenses * 0.88).toFixed(2)) },
+        { month: '2026-02-01', label: 'Feb', incomeAmount: monthlyIncome * 1.02, expenseAmount: monthlyExpenses * 1.05, netAmount: Number((monthlyIncome * 1.02 - monthlyExpenses * 1.05).toFixed(2)) },
+        { month: '2026-03-01', label: 'Mar', incomeAmount: monthlyIncome, expenseAmount: monthlyExpenses, netAmount: Number((monthlyIncome - monthlyExpenses).toFixed(2)) },
+      ]
+    })()
+    : buildRecentCashFlow(liveState.expenses, liveState.income, chartMonth, 3)
   const firstName = getFirstName(session?.user?.email)
-
+  const periodLabel = formatMonthPeriod(chartMonth)
+  const previewCategories = [...categoryCards]
+    .sort((left, right) => {
+      const leftBudgeted = left.monthlyLimit != null && Number(left.monthlyLimit) > 0
+      const rightBudgeted = right.monthlyLimit != null && Number(right.monthlyLimit) > 0
+      if (leftBudgeted && rightBudgeted) {
+        return (Number(right.progress) || 0) - (Number(left.progress) || 0)
+      }
+      if (leftBudgeted !== rightBudgeted) return leftBudgeted ? -1 : 1
+      return (Number(right.amount) || 0) - (Number(left.amount) || 0)
+    })
+    .slice(0, CATEGORY_PREVIEW_LIMIT)
+  const monthMarkerLabel = hudState.monthState?.monthLength
+    ? `Today · Day ${hudState.monthState.activeDay}`
+    : null
+  const chartSpendValue = trendPoints.length ? formatCurrency(trendPoints.at(-1) ?? 0) : '--'
   return (
     <>
     <section className="app-screen dashboard-screen">
@@ -593,7 +554,7 @@ export default function DashboardView() {
         className={`budget-hero budget-hero--${hudState.tone}${hudState.isOverBudget ? ' budget-hero--over' : ''}${hudState.isNearLimit ? ' budget-hero--risk' : ''}`}
       >
         <div className="budget-hero__topline">
-          <span className="budget-hero__eyebrow">{formatMonthPeriod(chartMonth)} budget HUD</span>
+          <span className="budget-hero__eyebrow">{periodLabel} budget HUD</span>
           <div className="budget-hero__actions">
             <span className={`budget-hero__badge budget-hero__badge--${hudState.tone}`}>{hudState.badge}</span>
             {!isSampleMode && (
@@ -604,108 +565,54 @@ export default function DashboardView() {
           </div>
         </div>
 
-        <div className="budget-hero__header">
-          <div className="budget-hero__headline">
-            <h2 className="budget-hero__value">{hudState.value}</h2>
-            <p className="budget-hero__suffix">{hudState.supportingText}</p>
-          </div>
+        <div className="budget-hero__headline">
+          <h2 className="budget-hero__value">{hudState.value}</h2>
+          <p className="budget-hero__suffix">{hudState.supportingText}</p>
         </div>
 
-        <div className="budget-hero__progress-block">
-          <div
-            aria-label="Monthly budget progress"
-            className="budget-progress budget-hero__progress"
-            role="progressbar"
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-valuenow={Math.round(hudState.progressPercentage)}
-            aria-valuetext={hudState.progressLabel}
-          >
-            <span
-              className={`budget-progress__fill budget-progress__fill--${hudState.tone}`}
-              style={{ width: hudState.progressWidth }}
-            />
-          </div>
-          <div className="budget-hero__progress-copy">
-            <strong>{hudState.progressLabel}</strong>
-            <span>{hudState.progressNote}</span>
-          </div>
-        </div>
+        <AllocationBar
+          progressPercentage={hudState.progressPercentage}
+          tone={hudState.tone}
+          ariaLabel="Monthly budget progress"
+          ariaValueText={hudState.progressLabel}
+          monthLength={hudState.monthState?.monthLength}
+          activeDay={hudState.monthState?.activeDay}
+          monthMarkerLabel={monthMarkerLabel}
+          isOverBudget={hudState.isOverBudget}
+          showMarker={hudState.hasBudget}
+        />
 
-        <div className="budget-hero__metrics">
-          {hudState.metrics.map((metric) => (
-            <div className="budget-hero__metric" key={metric.label}>
-              <span>{metric.label}</span>
-              <strong>{metric.value}</strong>
-              <small>{metric.hint}</small>
-            </div>
-          ))}
-        </div>
-
-        <div className={`budget-health-callout budget-health-callout--${financialHealth.tone}`}>
-          <div>
-            <span className="budget-health-callout__label">Financial health</span>
-            <strong>{financialHealth.label}</strong>
-          </div>
-          <p>
-            <span>{financialHealth.valueText}</span>
-            <small>{financialHealth.detailText}</small>
-          </p>
-        </div>
-
-        <div className={`budget-hero__pressure budget-hero__pressure--${pressureHighlight.tone}`}>
-          <div>
-            <span className="budget-hero__pressure-label">{pressureHighlight.label}</span>
-            <strong>{pressureHighlight.title}</strong>
-          </div>
-          <p>{pressureHighlight.detail}</p>
-        </div>
-
-        {trendPoints.length ? (
-          <div className="budget-hero__chart">
-            <svg aria-hidden="true" className="trend-chart" viewBox="0 0 312 148">
-              <defs>
-                <linearGradient id="budgetHeroFill" x1="0%" x2="0%" y1="0%" y2="100%">
-                  <stop offset="0%" stopColor="rgba(122, 181, 146, 0.26)" />
-                  <stop offset="100%" stopColor="rgba(122, 181, 146, 0.02)" />
-                </linearGradient>
-                <linearGradient id="budgetHeroOverrun" x1="0%" x2="0%" y1="0%" y2="100%">
-                  <stop offset="0%" stopColor="rgba(201, 130, 90, 0.28)" />
-                  <stop offset="100%" stopColor="rgba(201, 130, 90, 0.05)" />
-                </linearGradient>
-              </defs>
-              {projectedPath ? <path className="trend-chart__guide" d={projectedPath} fill="none" pathLength="1" /> : null}
-              <path className="trend-chart__fill" d={areaPath} fill="url(#budgetHeroFill)" />
-              {overrunPath ? <path className="trend-chart__overrun" d={overrunPath} fill="url(#budgetHeroOverrun)" /> : null}
-              <path className="trend-chart__line" d={linePath} fill="none" pathLength="1" />
-              {currentPoint ? (
-                <circle
-                  className={`trend-chart__point${overrunAmount > 0 ? ' trend-chart__point--warning' : ''}`}
-                  cx={currentPoint.x}
-                  cy={currentPoint.y}
-                  r="4.5"
-                />
-              ) : null}
-            </svg>
-            {currentPoint && trendPoints.length ? (
-              <div
-                className="budget-hero__callout"
-                style={{
-                  left: currentPointLeft,
-                  top: currentPointTop,
-                }}
-              >
-                {formatCurrency(trendPoints.at(-1) ?? 0)} spent
-              </div>
-            ) : null}
-          </div>
-        ) : (
-          <div className="blank-state blank-state--compact">
-            <strong>Waiting on activity</strong>
-            <span>This curve will appear once month-to-date spending lands.</span>
-          </div>
-        )}
+        <BudgetHudMetrics metrics={hudState.metrics} />
       </article>
+
+      <section className="section-block dashboard-trend">
+        <div className="section-headline">
+          <h2>Month pacing</h2>
+          <span className="section-link">{chartSpendValue} spent</span>
+        </div>
+
+        <MonthPacingChart
+          trendPoints={trendPoints}
+          budget={hudState.budget}
+          monthLength={hudState.monthState?.monthLength ?? 30}
+          activeDay={hudState.monthState?.activeDay ?? 0}
+          isOverBudget={hudState.isOverBudget}
+          emptyState={(
+            <div className="blank-state blank-state--compact">
+              <strong>Waiting on activity</strong>
+              <span>Your pacing line will appear once expenses land this month.</span>
+            </div>
+          )}
+        />
+      </section>
+
+      <section className="dashboard-glance dashboard-glance--single" aria-label="At a glance">
+        <FinancialHealthTile
+          health={financialHealth}
+          income={hudState.income}
+          expenses={hudState.spent}
+        />
+      </section>
 
       <section className="section-block">
         <div className="section-headline">
@@ -715,35 +622,31 @@ export default function DashboardView() {
           </Link>
         </div>
 
-        {categoryCards.length ? (
-          <div className="budget-glance-scroll">
-            <div className="budget-glance">
-              {categoryCards.map((item) => (
-                <div
-                  className="budget-glance__item"
-                  key={item.id}
-                  style={{
-                    '--entry-color': item.color,
-                    '--entry-soft': item.soft,
-                  }}
-                >
-                  <div
-                    className="budget-glance__ring"
-                    style={{
-                      background: `conic-gradient(var(--entry-color) 0 ${item.progress}%, rgba(122, 136, 127, 0.12) ${item.progress}% 100%)`,
-                    }}
-                  >
-                    <div className="budget-glance__inner">{item.symbol}</div>
-                  </div>
-                  {item.statusLabel ? (
-                    <span className={`budget-status-pill budget-status-pill--${item.statusTone}`}>{item.statusLabel}</span>
-                  ) : null}
-                  <strong>{item.name}</strong>
-                  <span>{formatCurrency(item.amount)}</span>
-                  <small>{item.note}</small>
-                </div>
-              ))}
-            </div>
+        {previewCategories.length ? (
+          <div className="category-progress-list">
+            {previewCategories.map((item) => (
+              <CategoryProgressRow
+                amount={item.amount}
+                color={item.color}
+                fallbackShareText={item.monthlyLimit == null ? item.note : null}
+                key={item.id}
+                monthlyLimit={item.monthlyLimit}
+                name={item.name}
+                onSelect={() => setCategoryDrillDown({
+                  name: item.name,
+                  symbol: item.symbol,
+                  color: item.color,
+                  soft: item.soft,
+                })}
+                progressPercentage={item.progress}
+                remainingAmount={item.remainingAmount}
+                selectLabel={`View ${item.name} transactions for ${periodLabel}`}
+                soft={item.soft}
+                statusLabel={item.statusLabel}
+                symbol={item.symbol}
+                tone={item.statusTone || 'neutral'}
+              />
+            ))}
           </div>
         ) : (
           <div className="blank-state blank-state--compact">
@@ -762,19 +665,48 @@ export default function DashboardView() {
             </Link>
           </div>
 
+          <div className="segment-control segment-control--strong dashboard-activity-filter" role="group" aria-label="Activity filter">
+            <button
+              aria-pressed={activityFilter === 'all'}
+              className={`segment-control__button${activityFilter === 'all' ? ' segment-control__button--active' : ''}`}
+              onClick={() => setActivityFilter('all')}
+              type="button"
+            >
+              All
+            </button>
+            <button
+              aria-pressed={activityFilter === 'expense'}
+              className={`segment-control__button${activityFilter === 'expense' ? ' segment-control__button--active' : ''}`}
+              onClick={() => setActivityFilter('expense')}
+              type="button"
+            >
+              Expenses
+            </button>
+            <button
+              aria-pressed={activityFilter === 'income'}
+              className={`segment-control__button${activityFilter === 'income' ? ' segment-control__button--active' : ''}`}
+              onClick={() => setActivityFilter('income')}
+              type="button"
+            >
+              Income
+            </button>
+          </div>
+
           {recentActivity.length ? (
             <div className="activity-feed">
               {recentActivity.map((entry) => {
                 const visual = getEntryVisual(entry)
 
                 return (
-                  <div
-                    className="activity-feed__row"
+                  <button
+                    className={`activity-feed__row activity-feed__row--${entry.kind} activity-feed__row--interactive`}
                     key={entry.id}
+                    onClick={() => setActivityDetailEntry(entry)}
                     style={{
                       '--entry-color': visual.color,
                       '--entry-soft': visual.soft,
                     }}
+                    type="button"
                   >
                     <div className="entry-avatar">
                       <span>{visual.symbol}</span>
@@ -792,63 +724,37 @@ export default function DashboardView() {
                       {entry.kind === 'income' ? '+' : '-'}
                       {formatCurrency(entry.amount)}
                     </div>
-                  </div>
+                  </button>
                 )
               })}
             </div>
           ) : (
             <div className="blank-state blank-state--compact">
-              <strong>No activity yet</strong>
-              <span>New transactions will land here once the month starts moving.</span>
+              <strong>
+                {activityFilter === 'income'
+                  ? 'No income yet'
+                  : activityFilter === 'expense'
+                    ? 'No expenses yet'
+                    : 'No activity yet'}
+              </strong>
+              <span>
+                {activityFilter === 'income'
+                  ? 'Income entries will show up here as they land.'
+                  : activityFilter === 'expense'
+                    ? 'Expenses will show up here as they land.'
+                    : 'New transactions will land here once the month starts moving.'}
+              </span>
             </div>
           )}
         </section>
 
-        <section className="section-block dashboard-panel dashboard-panel--income">
-          <div className="section-headline">
-            <h2>Recent income</h2>
-            <Link className="section-link" href="/transactions">
-              View all
-            </Link>
-          </div>
-
-          {recentIncome.length ? (
-            <div className="activity-feed">
-              {recentIncome.map((entry) => {
-                const visual = getEntryVisual(entry)
-                return (
-                  <div
-                    className="activity-feed__row"
-                    key={entry.id}
-                    style={{
-                      '--entry-color': visual.color,
-                      '--entry-soft': visual.soft,
-                    }}
-                  >
-                    <div className="entry-avatar">
-                      <span>{visual.symbol}</span>
-                    </div>
-                    <div className="entry-main">
-                      <strong>{entry.title}</strong>
-                      <div className="entry-meta">
-                        <span className="entry-chip">{entry.chip}</span>
-                        <span>{formatShortDate(entry.occurredOn)}</span>
-                      </div>
-                    </div>
-                    <div className="entry-amount entry-amount--income">
-                      +{formatCurrency(entry.amount)}
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          ) : (
-            <div className="blank-state blank-state--compact">
-              <strong>No income yet</strong>
-              <span>Income entries will show up here as they land.</span>
-            </div>
-          )}
-        </section>
+        <CashFlowSnapshot
+          expenses={hudState.spent}
+          income={hudState.income}
+          monthLabel={periodLabel}
+          trend={recentCashFlow}
+          viewMoreHref="/insights"
+        />
       </div>
     </section>
 
@@ -937,6 +843,23 @@ export default function DashboardView() {
             </form>
           </div>
         </div>
+      ) : null}
+
+      <CategoryTransactionsModal
+        category={categoryDrillDown}
+        currentMonthDetails={categoryTransactionDetails}
+        currentMonthLabel={periodLabel}
+        isOpen={Boolean(categoryDrillDown)}
+        onClose={() => setCategoryDrillDown(null)}
+        previousMonthDetails={null}
+        previousMonthLabel={null}
+      />
+
+      {activityDetailEntry ? (
+        <TransactionDetailSheet
+          entry={activityDetailEntry}
+          onClose={() => setActivityDetailEntry(null)}
+        />
       ) : null}
     </>
   )

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -267,6 +267,7 @@ export function getBudgetPressureHighlight(summary, expenses = [], derivedCatego
       name: card.name,
       note: card.note,
       progress: card.progress,
+      amount: card.amount,
     })),
   })
 }

--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useAuth, useDataMode } from '@/components/providers'
 import { ApiError, apiGet } from '@/lib/apiClient'
@@ -15,6 +16,11 @@ import {
   getCurrentMonthStart,
   shiftMonth,
 } from '@/lib/financeUtils'
+import AllocationBar from '@/components/ui/AllocationBar'
+import CategoryProgressRow from '@/components/ui/CategoryProgressRow'
+import CategoryTransactionsModal from '@/components/ui/CategoryTransactionsModal'
+import PaceVsLastMonthChart from '@/components/ui/PaceVsLastMonthChart'
+import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const DONUT_VIEWBOX = 520
 const DONUT_CENTER = DONUT_VIEWBOX / 2
@@ -25,7 +31,7 @@ const DONUT_MARKER_RADIUS = DONUT_OUTER_RADIUS + 42
 
 const CASHFLOW_WIDTH = 560
 const CASHFLOW_HEIGHT = 344
-const CASHFLOW_INSET_X = 28
+const CASHFLOW_INSET_X = 32
 const CASHFLOW_INSET_TOP = 24
 const CASHFLOW_INSET_BOTTOM = 52
 const CASHFLOW_BASELINE_RATIO = 0.53
@@ -91,6 +97,13 @@ function getMetricAccent(metricId) {
   if (metricId === 'net') return '\u223F'
   if (metricId === 'budget-left') return '\u25CE'
   return '\u2022'
+}
+
+function pickTopExpensesFromDetails(details = [], limit = 10) {
+  if (!Array.isArray(details) || !details.length) return []
+  return [...details]
+    .sort((left, right) => Number(right.amount ?? 0) - Number(left.amount ?? 0))
+    .slice(0, limit)
 }
 
 function getBudgetUsageHeadline(budgetHealth) {
@@ -244,53 +257,6 @@ function buildSmoothPath(points = []) {
   }, '')
 }
 
-const SPARKLINE_WIDTH = 320
-const SPARKLINE_HEIGHT = 60
-const SPARKLINE_PAD_X = 2
-const SPARKLINE_PAD_Y = 4
-
-function buildSparklineGeometry(series = [], highlightLastDays = 7) {
-  const points = []
-  if (!series.length) {
-    return { points, linePath: '', areaPath: '', highlightLinePath: '', highlightAreaPath: '', dividerX: null, baselineY: SPARKLINE_HEIGHT - SPARKLINE_PAD_Y }
-  }
-
-  const innerW = SPARKLINE_WIDTH - (SPARKLINE_PAD_X * 2)
-  const innerH = SPARKLINE_HEIGHT - (SPARKLINE_PAD_Y * 2)
-  const max = Math.max(...series.map((item) => Number(item.amount ?? 0)), 1)
-  const count = series.length
-
-  series.forEach((item, index) => {
-    const amount = Number(item.amount ?? 0)
-    const x = count === 1 ? SPARKLINE_PAD_X + (innerW / 2) : SPARKLINE_PAD_X + ((index / (count - 1)) * innerW)
-    const y = SPARKLINE_PAD_Y + innerH - ((amount / max) * innerH)
-    points.push({ x, y })
-  })
-
-  const baselineY = SPARKLINE_HEIGHT - SPARKLINE_PAD_Y
-  const linePath = buildSmoothPath(points)
-  const areaPath = points.length >= 2
-    ? `${linePath} L ${points.at(-1).x.toFixed(2)} ${baselineY.toFixed(2)} L ${points[0].x.toFixed(2)} ${baselineY.toFixed(2)} Z`
-    : ''
-
-  const highlightStartIndex = Math.max(count - highlightLastDays, 0)
-  const highlightPoints = points.slice(highlightStartIndex)
-  const highlightLinePath = buildSmoothPath(highlightPoints)
-  const highlightAreaPath = highlightPoints.length >= 2
-    ? `${highlightLinePath} L ${highlightPoints.at(-1).x.toFixed(2)} ${baselineY.toFixed(2)} L ${highlightPoints[0].x.toFixed(2)} ${baselineY.toFixed(2)} Z`
-    : ''
-
-  return {
-    points,
-    linePath,
-    areaPath,
-    highlightLinePath,
-    highlightAreaPath,
-    dividerX: highlightPoints.length > 0 && highlightStartIndex > 0 ? highlightPoints[0].x : null,
-    baselineY,
-  }
-}
-
 function buildCashFlowGeometry(series = []) {
   const plotBottom = CASHFLOW_HEIGHT - CASHFLOW_INSET_BOTTOM
   const chartHeight = plotBottom - CASHFLOW_INSET_TOP
@@ -339,6 +305,7 @@ function buildCashFlowGeometry(series = []) {
     baselineY,
     guides,
     groups,
+    maxBarValue,
     linePath: buildSmoothPath(groups.map((item) => ({ x: item.centerX, y: item.netY }))),
   }
 }
@@ -395,39 +362,29 @@ function buildDailyDetailMap(entries = []) {
   }, {})
 }
 
-function getTopExpenseBudgetMeter(item, expenseBreakdown = [], monthlyTotal = 0, topExpenseMax = 1) {
-  const matchedCategory = expenseBreakdown.find((category) => (
-    category.id === item.categoryId
-    || category.name === item.categoryName
-    || String(category.name || '').toLowerCase() === String(item.categoryName || '').toLowerCase()
-  ))
-  const amount = Number(item.amount ?? 0)
-  const budgetAmount = Number(matchedCategory?.monthlyLimit ?? 0)
-
-  if (matchedCategory?.hasBudget && budgetAmount > 0) {
-    const value = (amount / budgetAmount) * 100
+function buildCumulativeSeries(series = []) {
+  let running = 0
+  return series.map((item) => {
+    running += Number(item?.amount ?? 0)
     return {
-      label: 'Of category budget',
-      value,
-      width: clamp(value, amount > 0 ? 5 : 0, 100),
+      day: Number(item?.day ?? 0),
+      amount: Number(running.toFixed(2)),
     }
-  }
+  })
+}
 
-  if (monthlyTotal > 0) {
-    const value = (amount / monthlyTotal) * 100
-    return {
-      label: 'Of monthly spend',
-      value,
-      width: clamp(value, amount > 0 ? 5 : 0, 100),
-    }
-  }
+function getMonthLength(month) {
+  if (!month) return 31
+  const date = new Date(`${month}T12:00:00Z`)
+  if (Number.isNaN(date.getTime())) return 31
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0)).getUTCDate()
+}
 
-  const value = (amount / topExpenseMax) * 100
-  return {
-    label: 'Vs largest purchase',
-    value,
-    width: clamp(value, amount > 0 ? 12 : 0, 100),
-  }
+function getMonthShortLabel(month) {
+  if (!month) return 'Month'
+  const date = new Date(`${month}T12:00:00Z`)
+  if (Number.isNaN(date.getTime())) return 'Month'
+  return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })
 }
 
 function getDefaultSelectedDay(dailySpend) {
@@ -464,11 +421,18 @@ export default function InsightsView() {
   const [rhythmTooltip, setRhythmTooltip] = useState(null)
   const [isMonthViewOpen, setIsMonthViewOpen] = useState(false)
   const [selectedDayKey, setSelectedDayKey] = useState(null)
+  const [drillDown, setDrillDown] = useState(null)
+  const [topExpenseDetail, setTopExpenseDetail] = useState(null)
   const [liveState, setLiveState] = useState({ status: 'loading', message: '', snapshot: null })
 
   const activeMonth = isSampleMode ? DEMO_MONTH : selectedMonth
   const snapshot = isSampleMode ? demoInsightsSnapshot : liveState.snapshot
   const cashFlowSeries = snapshot?.cashFlowSeries ?? []
+  const rhythmTopExpenses = useMemo(() => {
+    const fromDetails = pickTopExpensesFromDetails(snapshot?.dailySpend?.details, 10)
+    if (fromDetails.length) return fromDetails
+    return (snapshot?.topExpenses ?? []).slice(0, 10)
+  }, [snapshot?.dailySpend?.details, snapshot?.topExpenses])
 
   useEffect(() => {
     if (isSampleMode || !isReady || !session?.accessToken) return
@@ -538,6 +502,15 @@ export default function InsightsView() {
     }
   }, [isMonthViewOpen])
 
+  useEffect(() => {
+    if (!topExpenseDetail) return undefined
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setTopExpenseDetail(null)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [topExpenseDetail])
+
   function openMonthView(event) {
     event?.preventDefault?.()
     event?.stopPropagation?.()
@@ -548,14 +521,12 @@ export default function InsightsView() {
   if (!isReady || !session?.accessToken) return null
 
   const activeItems = getActiveBreakdownItems(snapshot, viewMode)
-  const expenseItems = getActiveBreakdownItems(snapshot, 'expenses')
   const donutSegments = buildDonutSegments(activeItems)
   const comparisonMetrics = snapshot?.comparisonMetrics ?? []
-  const cashFlowSummary = snapshot?.cashFlowSummary ?? { totalIncome: 0, totalExpenses: 0, totalNet: 0, averageNet: 0 }
   const budgetHealth = snapshot?.budgetHealth ?? { tone: 'neutral', statusLabel: 'No budget', budgetAmount: null, spentAmount: 0, remainingAmount: null, progressValue: 0, pressureCategories: [] }
   const categoryMovers = snapshot?.categoryMovers ?? []
   const dailySpend = snapshot?.dailySpend ?? { series: [], totalAmount: 0, averageAmount: 0, activeDayAverage: 0, peakDay: null, activeDays: 0 }
-  const topExpenses = snapshot?.topExpenses ?? []
+  const previousDailySpend = snapshot?.previousDailySpend ?? { series: [], totalAmount: 0 }
   const currentLiveMonth = getCurrentMonthStart()
   const earliestMonth = isSampleMode ? DEMO_MONTH : snapshot?.earliestMonth
   const previousMonth = shiftMonth(activeMonth, -1)
@@ -566,7 +537,6 @@ export default function InsightsView() {
   const cashFlowGeometry = buildCashFlowGeometry(cashFlowSeries)
   const activeCashGroup = activeCashMonth ? cashFlowGeometry.groups.find((item) => item.month === activeCashMonth) ?? null : null
   const focusCashGroup = activeCashGroup ?? cashFlowGeometry.groups.at(-1) ?? null
-  const topExpenseMax = Math.max(...topExpenses.map((item) => Number(item.amount ?? 0)), 1)
   const dailyPeak = dailySpend.peakDay
   const calendarGrid = buildCalendarGrid(dailySpend.series, activeMonth)
   const rhythmBars = buildRhythmBars(dailySpend.series)
@@ -575,7 +545,6 @@ export default function InsightsView() {
   const selectedDayLabel = selectedDayKey ? formatLongDate(selectedDayKey) : activeMonthLabel
   const activeRhythmEntry = activeRhythmDay ? dailySpend.series.find((item) => item.key === activeRhythmDay) ?? null : null
   const centerLabelLines = viewMode === 'expenses' ? ['Spent', 'this month'] : ['Income', 'this month']
-  const budgetProgressWidth = budgetHealth.budgetAmount == null ? 0 : Math.max(Math.min(budgetHealth.progressValue ?? 0, 100), 4)
   const trailingCategoryId = activeItems.length > 2 && activeItems.length % 2 === 1 ? activeItems.at(-1)?.id : null
   const moverScaleMax = Math.max(
     ...categoryMovers.flatMap((entry) => [Number(entry.amount ?? 0), Number(entry.previousAmount ?? 0)]),
@@ -598,16 +567,14 @@ export default function InsightsView() {
   const cashFlowHealthCopy = focusCashGroup
     ? `${focusCashGroup.label} kept ${formatPercentage(focusSavingsRate ?? 0)} of income after expenses.`
     : 'Cash-flow highlights appear after a few months of activity.'
-  const topExpenseTotal = topExpenses.reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
-  const topExpenseShare = dailySpend.totalAmount > 0 ? (topExpenseTotal / dailySpend.totalAmount) * 100 : 0
-  const lastSevenSpend = dailySpend.series.slice(-7).reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
-  const lastSevenShare = dailySpend.totalAmount > 0 ? (lastSevenSpend / dailySpend.totalAmount) * 100 : 0
-  const rhythmPatternTitle = lastSevenShare >= 45 ? 'Late-month concentration' : 'Balanced month shape'
-  const rhythmPatternTone = lastSevenShare >= 45 ? 'warning' : 'positive'
-  const rhythmPatternCopy = dailySpend.totalAmount > 0
-    ? `Last 7 days ${formatPercentage(lastSevenShare)}. Top ${topExpenses.length} ${formatPercentage(topExpenseShare)}.`
-    : 'Daily and top-expense patterns appear once spending starts.'
-  const sparklineGeometry = buildSparklineGeometry(dailySpend.series, 7)
+
+  const paceCurrentSeries = buildCumulativeSeries(dailySpend.series)
+  const pacePreviousSeries = buildCumulativeSeries(previousDailySpend.series || [])
+  const previousMonthShortLabel = getMonthShortLabel(snapshot?.previousMonth || previousMonth)
+  const currentMonthShortLabel = getMonthShortLabel(activeMonth)
+  const isViewingCurrentMonth = activeMonth === currentLiveMonth
+  const todayDay = isViewingCurrentMonth ? new Date().getDate() : null
+
   const monthModal = isMonthViewOpen && portalRoot
     ? createPortal(
       <div className="insights-screen--issue57 insights-v57__month-modal-portal">
@@ -747,6 +714,24 @@ export default function InsightsView() {
       <LiveNotice message={liveState.message} onRetry={() => setReloadToken((value) => value + 1)} />
 
       <div className="insights-v57">
+        <div className="insights-v57__metric-strip">
+          {comparisonMetrics.map((metric) => (
+            <article className={`insights-v57__metric-card insights-v57__metric-card--${metric.deltaTone} insights-v57__metric-card--${metric.id}`} key={metric.id}>
+              <div className="insights-v57__metric-head">
+                <div className="insights-v57__metric-label">
+                  <span className={`insights-v57__metric-accent insights-v57__metric-accent--${metric.id}`}>{getMetricAccent(metric.id)}</span>
+                  <span>{metric.label}</span>
+                </div>
+                <div className="insights-v57__metric-trend">
+                  <span className={`insights-v57__metric-delta insights-v57__metric-delta--${metric.deltaTone}`}>{getMetricDeltaValue(metric)}</span>
+                  {getMetricDeltaContext(metric) ? <small>{getMetricDeltaContext(metric)}</small> : null}
+                </div>
+              </div>
+              <strong className="insights-v57__metric-value">{getMetricValue(metric)}</strong>
+            </article>
+          ))}
+        </div>
+
         <div className="insights-v57__top-grid">
           <article className="insights-v57__card insights-v57__hero">
             <div className="insights-v57__card-header insights-v57__card-header--hero">
@@ -760,7 +745,7 @@ export default function InsightsView() {
             </div>
 
             {activeItems.length ? (
-              <div className="insights-v57__hero-body">
+              <div className="insights-v57__hero-body insights-v57__hero-body--donut-only">
                 <div className="insights-v57__donut-shell">
                   <div className="insights-v57__donut" key={`${viewMode}-${activeMonth}`}>
                     <svg aria-hidden="true" className="insights-v57__donut-svg" viewBox={`0 0 ${DONUT_VIEWBOX} ${DONUT_VIEWBOX}`}>
@@ -811,34 +796,6 @@ export default function InsightsView() {
                     ))}
                   </div>
                 </div>
-
-                <div className="insights-v57__category-grid">
-                  {activeItems.map((item) => (
-                    <article className={`insights-v57__category-card insights-v57__category-card--${item.tone}${trailingCategoryId === item.id ? ' insights-v57__category-card--tail' : ''}`} key={item.id}>
-                      <div className="insights-v57__category-top">
-                        <div className="insights-v57__category-leading">
-                          <div className="insights-v57__category-icon" style={{ backgroundColor: item.soft, color: item.color }}>{item.symbol}</div>
-                          <div className="insights-v57__category-copy">
-                            <strong>{item.name}</strong>
-                            <span>{formatPercentage(item.share)}</span>
-                          </div>
-                        </div>
-                        <strong className="insights-v57__category-amount">{formatCurrency(item.amount)}</strong>
-                      </div>
-
-                      <div className="insights-v57__category-meta">
-                        <span className={`insights-v57__status-chip insights-v57__status-chip--${item.tone}`}>{item.statusLabel}</span>
-                        <small>{item.progressLabel}</small>
-                      </div>
-
-                      <div aria-label={`${item.name} progress`} aria-valuemax={100} aria-valuemin={0} aria-valuenow={Math.round(item.progressValue ?? 0)} aria-valuetext={item.progressLabel} className="insights-v57__category-progress" role="progressbar">
-                        <span className={`insights-v57__category-progress-fill insights-v57__category-progress-fill--${item.tone}`} style={{ width: `${Math.max(item.progressValue ?? 0, 4)}%` }} />
-                      </div>
-
-                      <p className="insights-v57__category-support">{item.supportingText}</p>
-                    </article>
-                  ))}
-                </div>
               </div>
             ) : (
               <div className="blank-state blank-state--hero">
@@ -851,7 +808,9 @@ export default function InsightsView() {
           <article className="insights-v57__card insights-v57__cashflow">
             <div className="insights-v57__card-header insights-v57__card-header--tight">
               <h2 className="insights-v57__title">Cash flow</h2>
-              <span className="insights-v57__range-chip">{snapshot?.cashFlowRangeLabel ?? 'Last 6 months'}</span>
+              <div className="insights-v57__cashflow-header-meta">
+                <span className="insights-v57__range-chip">{snapshot?.cashFlowRangeLabel ?? 'Last 6 months'}</span>
+              </div>
             </div>
 
             {cashFlowSeries.length ? (
@@ -957,13 +916,6 @@ export default function InsightsView() {
                     </div>
                   ) : null}
                 </div>
-
-                <div className="insights-v57__cashflow-summary">
-                  <div className="insights-v57__cashflow-summary-item"><span>Total income</span><strong>{formatCurrency(cashFlowSummary.totalIncome)}</strong></div>
-                  <div className="insights-v57__cashflow-summary-item"><span>Total expenses</span><strong>{formatCurrency(cashFlowSummary.totalExpenses)}</strong></div>
-                  <div className="insights-v57__cashflow-summary-item"><span>Net cash flow</span><strong>{formatCurrency(cashFlowSummary.totalNet)}</strong></div>
-                  <div className="insights-v57__cashflow-summary-item"><span>Cash flow / mo</span><strong>{formatCurrency(cashFlowSummary.averageNet)}</strong></div>
-                </div>
               </>
             ) : (
               <div className="blank-state blank-state--compact">
@@ -974,23 +926,35 @@ export default function InsightsView() {
           </article>
         </div>
 
-        <div className="insights-v57__metric-strip">
-          {comparisonMetrics.map((metric) => (
-            <article className={`insights-v57__metric-card insights-v57__metric-card--${metric.deltaTone} insights-v57__metric-card--${metric.id}`} key={metric.id}>
-              <div className="insights-v57__metric-head">
-                <div className="insights-v57__metric-label">
-                  <span className={`insights-v57__metric-accent insights-v57__metric-accent--${metric.id}`}>{getMetricAccent(metric.id)}</span>
-                  <span>{metric.label}</span>
-                </div>
-                <div className="insights-v57__metric-trend">
-                  <span className={`insights-v57__metric-delta insights-v57__metric-delta--${metric.deltaTone}`}>{getMetricDeltaValue(metric)}</span>
-                  {getMetricDeltaContext(metric) ? <small>{getMetricDeltaContext(metric)}</small> : null}
-                </div>
-              </div>
-              <strong className="insights-v57__metric-value">{getMetricValue(metric)}</strong>
-            </article>
-          ))}
-        </div>
+        {activeItems.length ? (
+          <section className="section-block insights-v57__detail-section" aria-label="Category detail">
+            <div className="section-headline">
+              <h2>Category detail</h2>
+              <span className="section-link">{formatCurrency(activeTotal)} {viewMode === 'expenses' ? 'spent' : 'earned'}</span>
+            </div>
+            <div className="category-progress-list category-progress-list--insights">
+              {activeItems.map((item) => (
+                <CategoryProgressRow
+                  amount={item.amount}
+                  color={item.color}
+                  fallbackShareText={!item.hasBudget ? item.progressLabel : null}
+                  key={item.id}
+                  monthlyLimit={item.hasBudget ? item.monthlyLimit : null}
+                  name={item.name}
+                  onSelect={viewMode === 'expenses' ? () => setDrillDown({ category: item, mode: 'single' }) : null}
+                  progressPercentage={item.progressValue ?? item.share ?? 0}
+                  remainingAmount={item.remainingBudget ?? null}
+                  selectLabel={`View ${item.name} transactions for ${activeMonthLabel}`}
+                  showStatusChip="always"
+                  soft={item.soft}
+                  statusLabel={item.statusLabel}
+                  symbol={item.symbol}
+                  tone={item.tone || 'neutral'}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
 
         <div className="insights-v57__bottom-grid">
           <article className="insights-v57__card insights-v57__budget-card">
@@ -1002,9 +966,17 @@ export default function InsightsView() {
                 <strong>{getBudgetUsageHeadline(budgetHealth)}</strong>
               </div>
 
-              <div className="insights-v57__budget-progress" role="presentation">
-                <span className={`insights-v57__budget-progress-fill insights-v57__budget-progress-fill--${budgetHealth.tone}`} style={{ width: `${budgetProgressWidth}%` }} />
-              </div>
+              <AllocationBar
+                activeDay={isViewingCurrentMonth ? todayDay : null}
+                ariaLabel="Budget health progress"
+                ariaValueText={`${Math.round(budgetHealth.progressValue ?? 0)}% used`}
+                isOverBudget={(budgetHealth.remainingAmount ?? 0) < 0}
+                monthLength={getMonthLength(activeMonth)}
+                monthMarkerLabel={isViewingCurrentMonth ? `Today · Day ${todayDay}` : null}
+                progressPercentage={budgetHealth.progressValue ?? 0}
+                showMarker={Boolean(budgetHealth.budgetAmount) && isViewingCurrentMonth}
+                tone={budgetHealth.tone}
+              />
 
               <div className="insights-v57__budget-overview-scale">
                 <span>Spent <strong>{formatCurrency(budgetHealth.spentAmount ?? 0)}</strong></span>
@@ -1017,28 +989,24 @@ export default function InsightsView() {
               <section className="insights-v57__budget-panel">
                 <div className="insights-v57__panel-head"><h3>Pressure</h3></div>
                 {budgetHealth.pressureCategories.length ? (
-                  <div className="insights-v57__pressure-list">
+                  <div className="category-progress-list category-progress-list--insights category-progress-list--compact">
                     {budgetHealth.pressureCategories.map((item) => (
-                      <div className={`insights-v57__pressure-row insights-v57__pressure-row--${item.tone}`} key={`pressure-${item.id}`}>
-                        <div className="insights-v57__pressure-head">
-                          <div className="insights-v57__pressure-main">
-                            <div className="insights-v57__pressure-icon" style={{ backgroundColor: item.soft, color: item.color }}>{item.symbol}</div>
-                            <div><strong>{item.name}</strong></div>
-                          </div>
-                          <div className="insights-v57__pressure-side">
-                            <strong>{item.progressLabel}</strong>
-                            <span className={`insights-v57__status-chip insights-v57__status-chip--${item.tone}`}>{item.statusLabel}</span>
-                          </div>
-                        </div>
-                        <div className="insights-v57__pressure-progress">
-                          <span className={`insights-v57__pressure-progress-fill insights-v57__pressure-progress-fill--${item.tone}`} style={{ width: `${Math.max(item.progressValue ?? 0, 4)}%` }} />
-                        </div>
-                        <div className="insights-v57__pressure-meta">
-                          <small><span>Budget</span><strong>{item.monthlyLimit == null ? 'None' : formatCurrency(item.monthlyLimit)}</strong></small>
-                          <small><span>Spent</span><strong>{formatCurrency(item.amount)}</strong></small>
-                          <small><span>{(item.remainingBudget ?? 0) < 0 ? 'Over' : 'Left'}</span><strong>{item.remainingBudget == null ? 'None' : formatCurrency(Math.abs(item.remainingBudget))}</strong></small>
-                        </div>
-                      </div>
+                      <CategoryProgressRow
+                        amount={item.amount}
+                        color={item.color}
+                        key={`pressure-${item.id}`}
+                        monthlyLimit={item.monthlyLimit}
+                        name={item.name}
+                        onSelect={() => setDrillDown({ category: item, mode: 'single' })}
+                        progressPercentage={item.progressValue ?? 0}
+                        remainingAmount={item.remainingBudget}
+                        selectLabel={`View ${item.name} pressure transactions for ${activeMonthLabel}`}
+                        showStatusChip="never"
+                        soft={item.soft}
+                        statusLabel={item.statusLabel}
+                        symbol={item.symbol}
+                        tone={item.tone || 'neutral'}
+                      />
                     ))}
                   </div>
                 ) : (
@@ -1054,7 +1022,13 @@ export default function InsightsView() {
                 {categoryMovers.length ? (
                   <div className="insights-v57__mover-list">
                     {categoryMovers.map((item) => (
-                      <div className="insights-v57__mover-row" key={item.id}>
+                      <button
+                        aria-label={`Compare ${item.name} between ${currentMonthShortLabel} and ${previousMonthShortLabel}`}
+                        className={`insights-v57__mover-row insights-v57__mover-row--${item.tone || 'neutral'} insights-v57__mover-row--interactive`}
+                        key={item.id}
+                        onClick={() => setDrillDown({ category: item, mode: 'compare' })}
+                        type="button"
+                      >
                         <div className="insights-v57__mover-head">
                           <div className="insights-v57__mover-main">
                             <div className="insights-v57__mover-icon" style={{ backgroundColor: item.soft, color: item.color }}>{item.symbol}</div>
@@ -1081,7 +1055,7 @@ export default function InsightsView() {
                             </div>
                           </div>
                         </div>
-                      </div>
+                      </button>
                     ))}
                   </div>
                 ) : (
@@ -1141,7 +1115,11 @@ export default function InsightsView() {
                 <div className="insights-v57__rhythm-summary">
                   <div className="insights-v57__rhythm-ribbon-item"><span>Active days</span><strong>{dailySpend.activeDays}</strong></div>
                   <div className="insights-v57__rhythm-ribbon-item"><span>Spend / active day</span><strong>{formatCurrency(dailySpend.activeDayAverage ?? dailySpend.averageAmount)}</strong></div>
-                  <div className="insights-v57__rhythm-ribbon-item"><span>Peak day</span><strong>{dailyPeak ? formatShortDate(dailyPeak.key) : 'None yet'}</strong></div>
+                  <div className="insights-v57__rhythm-ribbon-item insights-v57__rhythm-ribbon-item--peak">
+                    <span>Peak day</span>
+                    <strong>{dailyPeak ? formatShortDate(dailyPeak.key) : 'None yet'}</strong>
+                    {dailyPeak ? <small>{formatCurrency(dailyPeak.amount)}</small> : null}
+                  </div>
                 </div>
               </>
             ) : (
@@ -1151,75 +1129,80 @@ export default function InsightsView() {
               </div>
             )}
 
-            <div className="insights-v57__panel-head insights-v57__panel-head--expenses"><h3>Top expenses</h3></div>
-            {topExpenses.length ? (
-              <div className="insights-v57__top-expense-list">
-                {topExpenses.map((item, index) => {
-                  const meter = getTopExpenseBudgetMeter(item, expenseItems, dailySpend.totalAmount, topExpenseMax)
-                  return (
-                  <div className="insights-v57__top-expense-row" key={item.id}>
-                    <div className="insights-v57__top-expense-head">
-                      <span className="insights-v57__top-expense-rank">{String(index + 1).padStart(2, '0')}</span>
-                      <div className="insights-v57__top-expense-main">
-                        <div className="insights-v57__top-expense-icon" style={{ backgroundColor: item.soft, color: item.color }}>{item.symbol}</div>
-                        <div><strong>{item.title}</strong><span>{item.categoryName} | {formatShortDate(item.occurredOn)}</span></div>
+            {rhythmTopExpenses.length ? (
+              <section className="insights-v57__rhythm-top-expenses" aria-label="Top expenses">
+                <div className="insights-v57__rhythm-top-expenses-head">
+                  <h3 className="insights-v57__rhythm-top-expenses-title">Top expenses</h3>
+                  <Link className="insights-v57__top-expenses-more" href="/transactions">
+                    View more
+                  </Link>
+                </div>
+                <div className="insights-v57__top-expense-list insights-v57__top-expense-list--nested">
+                  {rhythmTopExpenses.map((item, index) => (
+                    <button
+                      className="insights-v57__top-expense-row insights-v57__top-expense-row--interactive"
+                      key={item.id}
+                      onClick={() => setTopExpenseDetail({
+                        id: item.id,
+                        kind: 'expense',
+                        title: item.title,
+                        chip: item.categoryName,
+                        amount: item.amount,
+                        occurredOn: item.occurredOn || item.key,
+                        note: item.categoryName,
+                        merchant: item.title,
+                      })}
+                      type="button"
+                    >
+                      <div className="insights-v57__top-expense-head">
+                        <span className="insights-v57__top-expense-rank">{String(index + 1).padStart(2, '0')}</span>
+                        <div className="insights-v57__top-expense-main">
+                          <div className="insights-v57__top-expense-icon" style={{ backgroundColor: item.soft, color: item.color }}>{item.symbol}</div>
+                          <div><strong>{item.title}</strong><span>{item.categoryName} · {formatShortDate(item.occurredOn)}</span></div>
+                        </div>
+                        <strong className="insights-v57__top-expense-amount">-{formatCurrency(item.amount)}</strong>
                       </div>
-                      <strong className="insights-v57__top-expense-amount">-{formatCurrency(item.amount)}</strong>
-                    </div>
-                    <div className="insights-v57__top-expense-meter-head">
-                      <span><strong>{formatPercentage(meter.value)}</strong> {meter.label.toLowerCase()}</span>
-                    </div>
-                    <div className="insights-v57__top-expense-meter">
-                      <span className="insights-v57__top-expense-meter-fill" style={{ width: `${meter.width}%`, background: item.color }} />
-                    </div>
-                  </div>
-                  )
-                })}
-              </div>
-            ) : (
-              <div className="blank-state blank-state--compact">
-                <strong>No top expenses yet</strong>
-                <span>Biggest purchases will surface here once the selected month has spending.</span>
-              </div>
-            )}
-            {topExpenses.length && dailySpend.totalAmount > 0 ? (
-              <div className={`insights-v57__spend-pattern insights-v57__spend-pattern--${rhythmPatternTone}`} aria-label={rhythmPatternCopy}>
-                <div className="insights-v57__spend-pattern-head">
-                  <span>Spend pattern</span>
-                  <strong>{rhythmPatternTitle}</strong>
+                    </button>
+                  ))}
                 </div>
-                {sparklineGeometry.points.length >= 2 ? (
-                  <svg
-                    aria-hidden="true"
-                    className={`insights-v57__sparkline insights-v57__sparkline--${rhythmPatternTone}`}
-                    preserveAspectRatio="none"
-                    viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
-                  >
-                    {sparklineGeometry.areaPath ? <path className="insights-v57__sparkline-area" d={sparklineGeometry.areaPath} /> : null}
-                    {sparklineGeometry.linePath ? <path className="insights-v57__sparkline-line" d={sparklineGeometry.linePath} /> : null}
-                    {sparklineGeometry.highlightAreaPath ? <path className="insights-v57__sparkline-highlight-area" d={sparklineGeometry.highlightAreaPath} /> : null}
-                    {sparklineGeometry.highlightLinePath ? <path className="insights-v57__sparkline-highlight-line" d={sparklineGeometry.highlightLinePath} /> : null}
-                    {sparklineGeometry.dividerX != null ? (
-                      <line
-                        className="insights-v57__sparkline-divider"
-                        x1={sparklineGeometry.dividerX}
-                        x2={sparklineGeometry.dividerX}
-                        y1={SPARKLINE_PAD_Y}
-                        y2={sparklineGeometry.baselineY}
-                      />
-                    ) : null}
-                  </svg>
-                ) : null}
-                <div className="insights-v57__spend-pattern-stats">
-                  <span><small>Last 7 days</small><strong>{formatPercentage(lastSevenShare)}</strong></span>
-                  <span><small>Top buys</small><strong>{formatPercentage(topExpenseShare)}</strong></span>
-                </div>
-              </div>
+              </section>
             ) : null}
           </article>
         </div>
+
+        <section className="section-block insights-v57__pace-section" aria-label="Month over month pace">
+          <div className="section-headline">
+            <h2>Pace vs last month</h2>
+            <span className="section-link">{currentMonthShortLabel} vs {previousMonthShortLabel}</span>
+          </div>
+          <div className="insights-v57__pace-card">
+            <PaceVsLastMonthChart
+              currentMonthSeries={paceCurrentSeries}
+              previousMonthSeries={pacePreviousSeries}
+              currentMonthLabel={currentMonthShortLabel}
+              previousMonthLabel={previousMonthShortLabel}
+              monthLength={getMonthLength(activeMonth)}
+            />
+          </div>
+        </section>
+
       </div>
       {monthModal}
+      <CategoryTransactionsModal
+        isOpen={Boolean(drillDown)}
+        onClose={() => setDrillDown(null)}
+        category={drillDown?.category ?? null}
+        currentMonthDetails={dailySpend.details ?? []}
+        previousMonthDetails={drillDown?.mode === 'compare' ? (previousDailySpend.details ?? []) : null}
+        currentMonthLabel={activeMonthLabel}
+        previousMonthLabel={formatMonthLabel(snapshot?.previousMonth || previousMonth)}
+      />
+      {topExpenseDetail ? (
+        <TransactionDetailSheet
+          entry={topExpenseDetail}
+          onClose={() => setTopExpenseDetail(null)}
+        />
+      ) : null}
     </section>
   )
 }

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -13,6 +13,7 @@ import {
   formatShortDate,
   groupActivityByDate,
 } from '@/lib/financeUtils'
+import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const ENTRY_CATEGORY_OPTIONS = {
   expense: ['Groceries', 'Dining', 'Shopping', 'Housing', 'Travel', 'Fun', 'Bills', 'Health'],
@@ -377,7 +378,6 @@ export default function TransactionsView() {
   })
   const groupedFeed = groupActivityByDate(filteredFeed)
   const isLoading = !isSampleMode && liveState.status === 'loading' && !feed.length
-  const selectedVisual = selectedEntry ? getEntryVisual(selectedEntry) : null
   const entryPreview = getCategoryVisual(
     [entryDraft.category, entryDraft.counterparty].filter(Boolean).join(' '),
     entryDraft.kind
@@ -389,16 +389,6 @@ export default function TransactionsView() {
   const entryCategories = entryDraft.kind === 'expense'
     ? (expenseCategories.length ? expenseCategories : ENTRY_CATEGORY_OPTIONS.expense.map((n) => ({ name: n, icon: null })))
     : (incomeCategories.length ? incomeCategories : ENTRY_CATEGORY_OPTIONS.income.map((n) => ({ name: n, icon: null })))
-  const selectedNote = selectedEntry && selectedEntry.note && selectedEntry.note !== selectedEntry.chip
-    ? selectedEntry.note
-    : selectedEntry?.kind === 'income'
-      ? 'No note added'
-      : 'Live expense'
-  const selectedSubtitle = selectedEntry
-    ? selectedEntry.merchant && selectedEntry.merchant !== selectedEntry.title
-      ? selectedEntry.merchant
-      : selectedEntry.note || selectedEntry.chip
-    : ''
   const hideFab = Boolean(selectedEntry) || isEntrySheetOpen
 
   const updateDraft = (field, value) => {
@@ -625,109 +615,54 @@ export default function TransactionsView() {
       </div>
 
       {selectedEntry ? (
-        <div className="detail-overlay" role="presentation">
-          <button
-            aria-label="Close transaction details"
-            className="detail-overlay__backdrop"
-            onClick={() => setSelectedEntry(null)}
-            type="button"
-          />
-          <div aria-labelledby="transaction-detail-title" aria-modal="true" className="detail-sheet" role="dialog">
-            <div className="detail-sheet__handle" />
-            <div
-              className="detail-sheet__hero"
-              style={{
-                '--entry-color': selectedVisual.color,
-                '--entry-soft': selectedVisual.soft,
-              }}
-            >
-              <div className="entry-avatar entry-avatar--large">
-                <span>{selectedVisual.symbol}</span>
-              </div>
-              <div className="detail-sheet__copy">
-                <span className="entry-chip">{selectedEntry.kind === 'income' ? 'Income' : 'Expense'}</span>
-                <h2 className="detail-sheet__title" id="transaction-detail-title">{selectedEntry.title}</h2>
-                <p className="detail-sheet__subtitle">{selectedSubtitle}</p>
-              </div>
-              <button className="button-secondary page-retry" onClick={() => setSelectedEntry(null)} type="button">
-                Close
-              </button>
-            </div>
-
-            <div className="detail-sheet__amount">
-              <span className={`entry-amount entry-amount--${selectedEntry.kind}`}>
-                {selectedEntry.kind === 'income' ? '+' : '-'}
-                {formatCurrency(selectedEntry.amount)}
-              </span>
-            </div>
-
-            <div className="detail-grid">
-              <div>
-                <span>Category</span>
-                <strong>{selectedEntry.chip}</strong>
-              </div>
-              <div>
-                <span>Date</span>
-                <strong>{formatLongDate(selectedEntry.occurredOn)}</strong>
-              </div>
-              <div>
-                <span>Type</span>
-                <strong>{selectedEntry.kind === 'income' ? 'Income' : 'Expense'}</strong>
-              </div>
-              <div>
-                <span>Note</span>
-                <strong>{selectedNote}</strong>
-              </div>
-            </div>
-
-            {!isSampleMode && selectedEntry.raw && (
-              <div className="entry-sheet__footer" style={{ marginTop: '1rem' }}>
-                {deleteConfirm ? (
-                  <>
-                    <div className="inline-error" role="alert">
-                      <span>Delete this transaction? This cannot be undone.</span>
-                    </div>
-                    <div className="entry-sheet__actions">
-                      <button
-                        className="button-secondary"
-                        disabled={isDeleting}
-                        onClick={() => setDeleteConfirm(false)}
-                        type="button"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        className="button-danger"
-                        disabled={isDeleting}
-                        onClick={handleDeleteEntry}
-                        type="button"
-                      >
-                        {isDeleting ? 'Deleting...' : 'Confirm delete'}
-                      </button>
-                    </div>
-                  </>
-                ) : (
+        <TransactionDetailSheet entry={selectedEntry} onClose={() => setSelectedEntry(null)}>
+          {!isSampleMode && selectedEntry.raw && (
+            <div className="entry-sheet__footer" style={{ marginTop: '1rem' }}>
+              {deleteConfirm ? (
+                <>
+                  <div className="inline-error" role="alert">
+                    <span>Delete this transaction? This cannot be undone.</span>
+                  </div>
                   <div className="entry-sheet__actions">
                     <button
                       className="button-secondary"
-                      onClick={() => openEntrySheet(selectedEntry)}
+                      disabled={isDeleting}
+                      onClick={() => setDeleteConfirm(false)}
                       type="button"
                     >
-                      Edit
+                      Cancel
                     </button>
                     <button
                       className="button-danger"
-                      onClick={() => setDeleteConfirm(true)}
+                      disabled={isDeleting}
+                      onClick={handleDeleteEntry}
                       type="button"
                     >
-                      Delete
+                      {isDeleting ? 'Deleting...' : 'Confirm delete'}
                     </button>
                   </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
+                </>
+              ) : (
+                <div className="entry-sheet__actions">
+                  <button
+                    className="button-secondary"
+                    onClick={() => openEntrySheet(selectedEntry)}
+                    type="button"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    className="button-danger"
+                    onClick={() => setDeleteConfirm(true)}
+                    type="button"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </TransactionDetailSheet>
       ) : null}
 
       {isEntrySheetOpen ? (

--- a/nextjs/src/components/ui/AllocationBar.js
+++ b/nextjs/src/components/ui/AllocationBar.js
@@ -1,0 +1,66 @@
+'use client'
+
+function clampPercent(value) {
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return 0
+  return Math.max(0, Math.min(amount, 100))
+}
+
+function getMonthMarkerPercent(activeDay, monthLength) {
+  if (!monthLength || monthLength <= 0) return null
+  if (!activeDay || activeDay <= 0) return null
+  const raw = (activeDay / monthLength) * 100
+  return clampPercent(raw)
+}
+
+export default function AllocationBar({
+  progressPercentage = 0,
+  tone = 'neutral',
+  ariaLabel = 'Budget progress',
+  ariaValueText,
+  monthLength = null,
+  activeDay = null,
+  monthMarkerLabel = null,
+  isOverBudget = false,
+  showMarker = true,
+}) {
+  const safeProgress = clampPercent(progressPercentage)
+  const markerPercent = showMarker ? getMonthMarkerPercent(activeDay, monthLength) : null
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={Math.round(safeProgress)}
+      aria-valuetext={ariaValueText || undefined}
+      className={`allocation-bar allocation-bar--${tone}${isOverBudget ? ' allocation-bar--over' : ''}`}
+      role="progressbar"
+    >
+      <span
+        className={`allocation-bar__fill allocation-bar__fill--${tone}`}
+        style={{ width: `${safeProgress}%` }}
+      />
+      {markerPercent != null ? (
+        <>
+          <span
+            aria-hidden="true"
+            className="allocation-bar__marker"
+            style={{ left: `${markerPercent}%` }}
+            data-testid="allocation-bar-marker"
+            title={monthMarkerLabel || undefined}
+          />
+          {monthMarkerLabel ? (
+            <span
+              aria-hidden="true"
+              className="allocation-bar__marker-label"
+              style={{ left: `${markerPercent}%` }}
+            >
+              {monthMarkerLabel}
+            </span>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/nextjs/src/components/ui/BudgetHudMetrics.js
+++ b/nextjs/src/components/ui/BudgetHudMetrics.js
@@ -1,0 +1,19 @@
+'use client'
+
+export default function BudgetHudMetrics({ metrics = [] }) {
+  if (!Array.isArray(metrics) || metrics.length === 0) return null
+
+  return (
+    <dl className="budget-hud-metrics">
+      {metrics.map((metric) => (
+        <div className="budget-hud-metrics__item" key={metric.label}>
+          <dt className="budget-hud-metrics__label">{metric.label}</dt>
+          <dd className="budget-hud-metrics__value">
+            <strong>{metric.value}</strong>
+            {metric.hint ? <small className="budget-hud-metrics__hint">{metric.hint}</small> : null}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/nextjs/src/components/ui/CashFlowSnapshot.js
+++ b/nextjs/src/components/ui/CashFlowSnapshot.js
@@ -1,0 +1,189 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+import { formatCurrency, formatPercentage } from '@/lib/financeUtils'
+
+function toSafeNumber(value) {
+  const amount = Number(value)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+function formatDelta(value) {
+  if (value == null || !Number.isFinite(value)) return '--'
+  const sign = value > 0 ? '+' : value < 0 ? '-' : ''
+  return `${sign}${formatCurrency(Math.abs(value))}`
+}
+
+export default function CashFlowSnapshot({
+  income,
+  expenses,
+  trend = [],
+  monthLabel = 'This month',
+  viewMoreHref = null,
+}) {
+  const [hoveredMonth, setHoveredMonth] = useState(null)
+
+  const safeIncome = toSafeNumber(income)
+  const safeExpenses = toSafeNumber(expenses)
+  const netAmount = Number((safeIncome - safeExpenses).toFixed(2))
+  const tone = netAmount > 0 ? 'positive' : netAmount < 0 ? 'danger' : 'neutral'
+  const hasMonthData = safeIncome > 0 || safeExpenses > 0
+  const trendPeak = trend.reduce(
+    (acc, item) => Math.max(acc, Math.abs(toSafeNumber(item?.netAmount))),
+    0,
+  )
+  const hoveredTrendItem = hoveredMonth
+    ? trend.find((item) => item.month === hoveredMonth) ?? null
+    : null
+  const trendReadoutItem = hoveredTrendItem ?? (trend.length ? trend[trend.length - 1] : null)
+  const trendFocus = Boolean(hoveredTrendItem)
+  const displayIncome = trendFocus
+    ? toSafeNumber(hoveredTrendItem.incomeAmount)
+    : safeIncome
+  const displayExpenses = trendFocus
+    ? toSafeNumber(hoveredTrendItem.expenseAmount)
+    : safeExpenses
+  const displayNet = trendFocus
+    ? toSafeNumber(hoveredTrendItem.netAmount)
+    : netAmount
+  const displaySavings = displayIncome > 0
+    ? (displayNet / displayIncome) * 100
+    : null
+  const displayLabel = trendFocus && hoveredTrendItem
+    ? hoveredTrendItem.label
+    : monthLabel
+  const maxBarValue = Math.max(displayIncome, displayExpenses, 1)
+  const incomeBarWidth = Math.max((displayIncome / maxBarValue) * 100, displayIncome > 0 ? 4 : 0)
+  const expenseBarWidth = Math.max((displayExpenses / maxBarValue) * 100, displayExpenses > 0 ? 4 : 0)
+  const displayTone = displayNet > 0 ? 'positive' : displayNet < 0 ? 'danger' : 'neutral'
+  const readoutNet = trendReadoutItem ? toSafeNumber(trendReadoutItem.netAmount) : null
+  const readoutTone = readoutNet == null ? 'neutral' : readoutNet >= 0 ? 'positive' : 'danger'
+
+  return (
+    <article
+      aria-label={`Cash flow for ${displayLabel}`}
+      className={`cashflow-snapshot cashflow-snapshot--${displayTone}`}
+    >
+      <div className="cashflow-snapshot__header">
+        <div className="cashflow-snapshot__headings">
+          <h2 className="cashflow-snapshot__heading">Cash flow</h2>
+          <p className="cashflow-snapshot__period">
+            {displayLabel}
+            {trendFocus ? <span className="cashflow-snapshot__period-hint"> · trend month</span> : null}
+          </p>
+        </div>
+        {viewMoreHref ? (
+          <Link className="section-link" href={viewMoreHref}>
+            View more
+          </Link>
+        ) : null}
+      </div>
+
+      {hasMonthData || trendFocus ? (
+        <div className="cashflow-snapshot__bars" aria-hidden="true">
+          <div className="cashflow-snapshot__row cashflow-snapshot__row--income">
+            <span className="cashflow-snapshot__row-label">Income</span>
+            <span className="cashflow-snapshot__row-bar">
+              <span
+                className="cashflow-snapshot__row-fill cashflow-snapshot__row-fill--income"
+                style={{ width: `${incomeBarWidth}%` }}
+              />
+            </span>
+            <strong className="cashflow-snapshot__row-value">{formatCurrency(displayIncome)}</strong>
+          </div>
+          <div className="cashflow-snapshot__row cashflow-snapshot__row--expense">
+            <span className="cashflow-snapshot__row-label">Expenses</span>
+            <span className="cashflow-snapshot__row-bar">
+              <span
+                className="cashflow-snapshot__row-fill cashflow-snapshot__row-fill--expense"
+                style={{ width: `${expenseBarWidth}%` }}
+              />
+            </span>
+            <strong className="cashflow-snapshot__row-value">{formatCurrency(displayExpenses)}</strong>
+          </div>
+        </div>
+      ) : (
+        <p className="cashflow-snapshot__empty">Your income vs expense shape will appear once the month has activity.</p>
+      )}
+
+      <div className="cashflow-snapshot__summary">
+        <div className={`cashflow-snapshot__net cashflow-snapshot__net--${displayTone}`}>
+          <span>Net</span>
+          <strong>
+            {displayNet > 0 ? '+' : ''}
+            {formatCurrency(displayNet)}
+          </strong>
+        </div>
+        <div className="cashflow-snapshot__savings">
+          <span>Savings rate</span>
+          <strong>{displaySavings == null ? '--' : formatPercentage(displaySavings)}</strong>
+        </div>
+      </div>
+
+      {trend.length ? (
+        <div
+          className="cashflow-snapshot__trend"
+          aria-label="Recent net cash flow trend"
+          role="group"
+          onMouseLeave={() => setHoveredMonth(null)}
+        >
+          <p className="cashflow-snapshot__trend-caption">Last 3 months — net after expenses</p>
+          <div className="cashflow-snapshot__trend-bars">
+            {trend.map((item) => {
+              const value = toSafeNumber(item.netAmount)
+              const heightRatio = trendPeak > 0 ? Math.abs(value) / trendPeak : 0
+              const barHeight = Math.max(heightRatio * 100, value !== 0 ? 8 : 0)
+              const barTone = value >= 0 ? 'positive' : 'danger'
+              const isFocused = trendReadoutItem?.month === item.month
+              const barOpacity = isFocused ? 1 : 0.45 + (heightRatio * 0.55)
+              return (
+                <button
+                  aria-label={`${item.label} net ${formatDelta(value)}`}
+                  aria-pressed={isFocused}
+                  className={`cashflow-snapshot__trend-col cashflow-snapshot__trend-col--${barTone}${isFocused ? ' cashflow-snapshot__trend-col--focused' : ''}`}
+                  key={item.month}
+                  onMouseEnter={() => setHoveredMonth(item.month)}
+                  onFocus={() => setHoveredMonth(item.month)}
+                  onBlur={() => setHoveredMonth(null)}
+                  type="button"
+                >
+                  <span className="cashflow-snapshot__trend-bar-wrap">
+                    <span
+                      aria-hidden="true"
+                      className={`cashflow-snapshot__trend-bar cashflow-snapshot__trend-bar--${barTone}`}
+                      style={{ height: `${barHeight}%`, opacity: barOpacity }}
+                    />
+                  </span>
+                  <small>{item.label}</small>
+                </button>
+              )
+            })}
+          </div>
+          <div className={`cashflow-snapshot__trend-readout cashflow-snapshot__trend-readout--${readoutTone}`} role="status">
+            <div className="cashflow-snapshot__trend-readout-main">
+              <span>
+                {trendReadoutItem
+                  ? (hoveredTrendItem ? `${hoveredTrendItem.label} selected` : `${trendReadoutItem.label} latest`)
+                  : '3-month net trend'}
+              </span>
+              <strong>{formatDelta(readoutNet)}</strong>
+            </div>
+            {trendReadoutItem ? (
+              <div className="cashflow-snapshot__trend-readout-detail">
+                <span>Inc {formatCurrency(toSafeNumber(trendReadoutItem.incomeAmount))}</span>
+                <span>Exp {formatCurrency(toSafeNumber(trendReadoutItem.expenseAmount))}</span>
+                <span>
+                  Save{' '}
+                  {toSafeNumber(trendReadoutItem.incomeAmount) > 0
+                    ? formatPercentage((toSafeNumber(trendReadoutItem.netAmount) / toSafeNumber(trendReadoutItem.incomeAmount)) * 100)
+                    : '—'}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </article>
+  )
+}

--- a/nextjs/src/components/ui/CategoryProgressRow.js
+++ b/nextjs/src/components/ui/CategoryProgressRow.js
@@ -1,0 +1,90 @@
+'use client'
+
+import { formatCurrency } from '@/lib/financeUtils'
+
+function clampPercent(value) {
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return 0
+  return Math.max(0, Math.min(amount, 100))
+}
+
+function shouldRenderChip(statusLabel, tone, mode) {
+  if (!statusLabel) return false
+  if (mode === 'always') return true
+  if (mode === 'never') return false
+  return tone === 'warning' || tone === 'danger'
+}
+
+export default function CategoryProgressRow({
+  name,
+  symbol,
+  color = 'var(--accent)',
+  soft = 'var(--accent-soft)',
+  amount = 0,
+  monthlyLimit = null,
+  progressPercentage = 0,
+  remainingAmount = null,
+  tone = 'neutral',
+  statusLabel = null,
+  fallbackShareText = null,
+  showStatusChip = 'auto',
+  onSelect = null,
+  selectLabel = null,
+}) {
+  const hasBudget = monthlyLimit != null && Number(monthlyLimit) > 0
+  const isOverBudget = hasBudget && remainingAmount != null && Number(remainingAmount) < 0
+  const safeProgress = clampPercent(progressPercentage)
+  const barFillWidth = Math.max(safeProgress, amount > 0 ? 4 : 0)
+  const amountDisplay = hasBudget
+    ? `${formatCurrency(amount)} / ${formatCurrency(monthlyLimit)}`
+    : formatCurrency(amount)
+  const chipVisible = shouldRenderChip(statusLabel, tone, showStatusChip)
+  const isInteractive = typeof onSelect === 'function'
+  const Tag = isInteractive ? 'button' : 'div'
+  const interactiveProps = isInteractive
+    ? {
+      type: 'button',
+      onClick: onSelect,
+      'aria-label': selectLabel || `View ${name} transactions`,
+    }
+    : {}
+
+  return (
+    <Tag
+      className={`category-progress-row category-progress-row--${tone}${isOverBudget ? ' category-progress-row--over' : ''}${isInteractive ? ' category-progress-row--interactive' : ''}`}
+      style={{ '--entry-color': color, '--entry-soft': soft }}
+      {...interactiveProps}
+    >
+      <div className="category-progress-row__main">
+        <span className="category-progress-row__icon" aria-hidden="true">{symbol}</span>
+        <div className="category-progress-row__copy">
+          <div className="category-progress-row__title-wrap">
+            <strong>{name}</strong>
+            {chipVisible ? (
+              <span className={`category-progress-row__chip category-progress-row__chip--${tone}`}>
+                {statusLabel}
+              </span>
+            ) : null}
+          </div>
+          {fallbackShareText && !hasBudget ? <small>{fallbackShareText}</small> : null}
+        </div>
+      </div>
+      <div
+        aria-label={`${name} ${hasBudget ? 'budget progress' : 'share of spend'}`}
+        aria-valuemax={100}
+        aria-valuemin={0}
+        aria-valuenow={Math.round(safeProgress)}
+        className="category-progress-row__bar"
+        role="progressbar"
+      >
+        <span
+          className={`category-progress-row__bar-fill category-progress-row__bar-fill--${tone}`}
+          style={{ width: `${barFillWidth}%` }}
+        />
+      </div>
+      <div className="category-progress-row__meta">
+        <strong>{amountDisplay}</strong>
+      </div>
+    </Tag>
+  )
+}

--- a/nextjs/src/components/ui/CategoryTransactionsModal.js
+++ b/nextjs/src/components/ui/CategoryTransactionsModal.js
@@ -1,0 +1,188 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { formatCurrency, formatShortDate } from '@/lib/financeUtils'
+
+function compareCategoryName(name) {
+  return String(name || '').trim().toLowerCase()
+}
+
+function filterByCategory(details = [], categoryName) {
+  const target = compareCategoryName(categoryName)
+  if (!target) return []
+  return details
+    .filter((entry) => compareCategoryName(entry?.categoryName) === target)
+    .map((entry) => ({ ...entry, amount: Number(entry?.amount ?? 0) }))
+    .sort((left, right) => right.amount - left.amount)
+}
+
+function totalAmount(entries) {
+  return entries.reduce((sum, entry) => sum + Number(entry?.amount ?? 0), 0)
+}
+
+function TransactionList({ entries, monthLabel, emptyCopy }) {
+  if (!entries.length) {
+    return (
+      <div className="blank-state blank-state--compact category-modal__empty">
+        <strong>No transactions{monthLabel ? ` in ${monthLabel}` : ''}</strong>
+        <span>{emptyCopy ?? 'Spending in this category will appear here once it lands.'}</span>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="category-modal__list" role="list">
+      {entries.map((entry) => (
+        <li className="category-modal__row" key={entry.id}>
+          <div className="category-modal__row-icon" style={{ backgroundColor: entry.soft, color: entry.color }} aria-hidden="true">
+            {entry.symbol}
+          </div>
+          <div className="category-modal__row-copy">
+            <strong>{entry.title}</strong>
+            <span>{formatShortDate(entry.occurredOn || entry.key)}</span>
+          </div>
+          <strong className="category-modal__row-amount">-{formatCurrency(entry.amount)}</strong>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default function CategoryTransactionsModal({
+  isOpen,
+  onClose,
+  category,
+  currentMonthDetails = [],
+  previousMonthDetails = null,
+  currentMonthLabel,
+  previousMonthLabel,
+}) {
+  const [portalRoot, setPortalRoot] = useState(null)
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') setPortalRoot(document.body)
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen || typeof document === 'undefined') return undefined
+    const previousOverflow = document.body.style.overflow
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') onClose?.()
+    }
+    document.body.style.overflow = 'hidden'
+    window.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.body.style.overflow = previousOverflow
+      window.removeEventListener('keydown', onKeyDown)
+    }
+  }, [isOpen, onClose])
+
+  const currentEntries = useMemo(
+    () => filterByCategory(currentMonthDetails, category?.name),
+    [currentMonthDetails, category?.name],
+  )
+  const previousEntries = useMemo(
+    () => (previousMonthDetails ? filterByCategory(previousMonthDetails, category?.name) : []),
+    [previousMonthDetails, category?.name],
+  )
+  const showCompare = previousMonthDetails != null
+
+  if (!isOpen || !portalRoot || !category) return null
+
+  const currentTotal = totalAmount(currentEntries)
+  const previousTotal = totalAmount(previousEntries)
+  const delta = showCompare ? Number((currentTotal - previousTotal).toFixed(2)) : null
+  const deltaTone = delta == null ? 'neutral' : delta > 0 ? 'danger' : delta < 0 ? 'positive' : 'neutral'
+
+  return createPortal(
+    <div className="category-modal-overlay" role="presentation">
+      <button
+        aria-label={`Close ${category.name} transactions`}
+        className="category-modal-overlay__backdrop"
+        onClick={onClose}
+        type="button"
+      />
+      <div
+        aria-labelledby="category-modal-title"
+        aria-modal="true"
+        className={`category-modal${showCompare ? ' category-modal--compare' : ''}`}
+        role="dialog"
+      >
+        <header
+          className="category-modal__header"
+          style={{ '--entry-color': category.color, '--entry-soft': category.soft }}
+        >
+          <div className="category-modal__header-icon" aria-hidden="true">
+            <span>{category.symbol}</span>
+          </div>
+          <div className="category-modal__header-copy">
+            <span className="category-modal__eyebrow">Category transactions</span>
+            <h2 className="category-modal__title" id="category-modal-title">{category.name}</h2>
+            {showCompare ? (
+              <p className="category-modal__subtitle">
+                {currentMonthLabel} vs {previousMonthLabel}
+              </p>
+            ) : currentMonthLabel ? (
+              <p className="category-modal__subtitle">{currentMonthLabel}</p>
+            ) : null}
+          </div>
+          <button
+            aria-label="Close"
+            className="category-modal__close"
+            onClick={onClose}
+            type="button"
+          >
+            ×
+          </button>
+        </header>
+
+        <dl className="category-modal__totals">
+          <div>
+            <dt>{currentMonthLabel || 'This month'}</dt>
+            <dd>{formatCurrency(currentTotal)}</dd>
+          </div>
+          {showCompare ? (
+            <>
+              <div>
+                <dt>{previousMonthLabel || 'Last month'}</dt>
+                <dd>{formatCurrency(previousTotal)}</dd>
+              </div>
+              <div className={`category-modal__totals-delta category-modal__totals-delta--${deltaTone}`}>
+                <dt>Change</dt>
+                <dd>
+                  {delta == null ? '--' : delta === 0 ? 'No change' : (
+                    <>
+                      {delta > 0 ? '+' : '-'}
+                      {formatCurrency(Math.abs(delta))}
+                    </>
+                  )}
+                </dd>
+              </div>
+            </>
+          ) : null}
+        </dl>
+
+        {showCompare ? (
+          <div className="category-modal__compare">
+            <section className="category-modal__column">
+              <h3 className="category-modal__column-heading">{currentMonthLabel || 'This month'}</h3>
+              <TransactionList entries={currentEntries} monthLabel={currentMonthLabel} />
+            </section>
+            <section className="category-modal__column">
+              <h3 className="category-modal__column-heading">{previousMonthLabel || 'Last month'}</h3>
+              <TransactionList
+                entries={previousEntries}
+                monthLabel={previousMonthLabel}
+                emptyCopy="No spending in this category last month."
+              />
+            </section>
+          </div>
+        ) : (
+          <TransactionList entries={currentEntries} monthLabel={currentMonthLabel} />
+        )}
+      </div>
+    </div>,
+    portalRoot,
+  )
+}

--- a/nextjs/src/components/ui/FinancialHealthTile.js
+++ b/nextjs/src/components/ui/FinancialHealthTile.js
@@ -1,0 +1,79 @@
+'use client'
+
+import { formatCurrency } from '@/lib/financeUtils'
+
+function toSafeNumber(value) {
+  const amount = Number(value)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+function buildSegments(income, expenses) {
+  const total = Math.max(income + expenses, 0)
+  if (total <= 0) {
+    return { incomeWidth: 0, expenseWidth: 0, total: 0 }
+  }
+  return {
+    incomeWidth: Math.max((income / total) * 100, income > 0 ? 4 : 0),
+    expenseWidth: Math.max((expenses / total) * 100, expenses > 0 ? 4 : 0),
+    total,
+  }
+}
+
+export default function FinancialHealthTile({ health, income, expenses }) {
+  if (!health) return null
+
+  const safeIncome = toSafeNumber(income)
+  const safeExpenses = toSafeNumber(expenses)
+  const { incomeWidth, expenseWidth, total } = buildSegments(safeIncome, safeExpenses)
+  const tone = health.tone || 'neutral'
+  const isUnavailable = health.key === 'unavailable' || health.key === 'loading'
+  const showSegments = !isUnavailable && total > 0
+
+  return (
+    <article
+      aria-label={`Financial health: ${health.label}`}
+      className={`health-tile health-tile--${tone}`}
+    >
+      <header className="health-tile__header">
+        <span className="health-tile__eyebrow">Financial health</span>
+        <strong className="health-tile__label">{health.label}</strong>
+      </header>
+
+      {showSegments ? (
+        <>
+          <div
+            aria-hidden="true"
+            className="health-tile__bar"
+          >
+            <span
+              className="health-tile__segment health-tile__segment--income"
+              style={{ width: `${incomeWidth}%` }}
+            />
+            <span
+              className="health-tile__segment health-tile__segment--expense"
+              style={{ width: `${expenseWidth}%` }}
+            />
+          </div>
+
+          <dl className="health-tile__legend">
+            <div>
+              <dt>Income</dt>
+              <dd>{formatCurrency(safeIncome)}</dd>
+            </div>
+            <div>
+              <dt>Expenses</dt>
+              <dd>{formatCurrency(safeExpenses)}</dd>
+            </div>
+          </dl>
+        </>
+      ) : (
+        <p className="health-tile__placeholder">{health.detailText}</p>
+      )}
+
+      <div className={`health-tile__net health-tile__net--${tone}`}>
+        <span>Net</span>
+        <strong>{health.valueText}</strong>
+      </div>
+    </article>
+  )
+}

--- a/nextjs/src/components/ui/MonthPacingChart.js
+++ b/nextjs/src/components/ui/MonthPacingChart.js
@@ -1,0 +1,340 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { buildTrendChartAxes, formatCurrency } from '@/lib/financeUtils'
+import TrendChartAxes from '@/components/ui/TrendChartAxes'
+
+const CHART_WIDTH = 360
+const CHART_HEIGHT = 168
+const CHART_INSET_X = 12
+const CHART_INSET_TOP = 16
+const CHART_INSET_BOTTOM = 22
+
+function buildLinePath(points) {
+  if (!points.length) return ''
+  return points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+    .join(' ')
+}
+
+function buildAreaPath(points, baselineY) {
+  if (points.length < 2) return ''
+  const linePath = buildLinePath(points)
+  const last = points[points.length - 1]
+  const first = points[0]
+  return `${linePath} L ${last.x.toFixed(2)} ${baselineY} L ${first.x.toFixed(2)} ${baselineY} Z`
+}
+
+function getCeiling(values, budget) {
+  const filtered = values.filter((value) => Number.isFinite(value))
+  const max = filtered.length ? Math.max(...filtered) : 0
+  if (budget > 0) return Math.max(max * 1.06, budget * 1.06, 1)
+  return Math.max(max * 1.18, max + 120, 1)
+}
+
+function projectPoints(values, ceiling) {
+  const plotWidth = CHART_WIDTH - CHART_INSET_X * 2
+  const plotHeight = CHART_HEIGHT - CHART_INSET_TOP - CHART_INSET_BOTTOM
+  return values.map((value, index) => {
+    const xRatio = values.length > 1 ? index / (values.length - 1) : 0
+    const yRatio = ceiling > 0 ? Math.min(value / ceiling, 1) : 0
+    return {
+      x: CHART_INSET_X + plotWidth * xRatio,
+      y: CHART_INSET_TOP + plotHeight * (1 - yRatio),
+      value,
+      day: index + 1,
+    }
+  })
+}
+
+function clampIndex(index, length) {
+  if (length <= 0) return 0
+  return Math.max(0, Math.min(index, length - 1))
+}
+
+function getDeltaTone(actual, pace) {
+  if (pace == null) return 'neutral'
+  const delta = actual - pace
+  const threshold = Math.max(pace * 0.03, 5)
+  if (Math.abs(delta) <= threshold) return 'warning'
+  return delta > 0 ? 'danger' : 'positive'
+}
+
+function getSegmentTone(actualValue, paceValue) {
+  if (paceValue == null || paceValue <= 0) return 'neutral'
+  const delta = actualValue - paceValue
+  const threshold = Math.max(paceValue * 0.03, 5)
+  if (Math.abs(delta) <= threshold) return 'warning'
+  return delta > 0 ? 'danger' : 'positive'
+}
+
+function buildSegmentedPaths(points, paceValues) {
+  if (points.length < 2 || !paceValues.length) {
+    return [{ tone: 'neutral', d: buildLinePath(points) }]
+  }
+  const segments = []
+  let currentTone = getSegmentTone(points[0].value, paceValues[0])
+  let currentPoints = [points[0]]
+
+  for (let i = 1; i < points.length; i += 1) {
+    const tone = getSegmentTone(points[i].value, paceValues[i])
+    if (tone !== currentTone) {
+      segments.push({ tone: currentTone, d: buildLinePath(currentPoints) })
+      currentPoints = [points[i - 1]]
+      currentTone = tone
+    }
+    currentPoints.push(points[i])
+  }
+  if (currentPoints.length >= 1) {
+    segments.push({ tone: currentTone, d: buildLinePath(currentPoints) })
+  }
+  return segments
+}
+
+export default function MonthPacingChart({
+  trendPoints = [],
+  budget = 0,
+  monthLength = 30,
+  activeDay = null,
+  isOverBudget = false,
+  emptyState = null,
+}) {
+  const [hoverIndex, setHoverIndex] = useState(null)
+
+  const ceiling = useMemo(() => getCeiling(trendPoints, budget), [trendPoints, budget])
+  const points = useMemo(() => projectPoints(trendPoints, ceiling), [trendPoints, ceiling])
+
+  const paceValues = useMemo(() => {
+    if (budget <= 0 || monthLength <= 0) return []
+    return trendPoints.map((_, index) => {
+      const day = index + 1
+      return Number(((budget * day) / Math.max(monthLength, 1)).toFixed(2))
+    })
+  }, [budget, monthLength, trendPoints])
+
+  const segmentedPaths = useMemo(
+    () => buildSegmentedPaths(points, paceValues),
+    [points, paceValues]
+  )
+  const axes = useMemo(() => buildTrendChartAxes({
+    budget,
+    monthLength,
+    activeDay: activeDay ?? trendPoints.length,
+    pointCount: trendPoints.length,
+    width: CHART_WIDTH,
+    height: CHART_HEIGHT,
+    inset: CHART_INSET_X,
+    insetTop: CHART_INSET_TOP,
+    insetBottom: CHART_INSET_BOTTOM,
+    valueCeiling: ceiling,
+  }), [budget, ceiling, monthLength, activeDay, trendPoints.length])
+
+  if (!trendPoints.length) {
+    return emptyState
+  }
+
+  const baselineY = CHART_HEIGHT - CHART_INSET_BOTTOM
+  const linePath = buildLinePath(points)
+  const areaPath = buildAreaPath(points, baselineY)
+  const lastIndex = points.length - 1
+  const focusedIndex = hoverIndex == null ? lastIndex : clampIndex(hoverIndex, points.length)
+  const focusedPoint = points[focusedIndex]
+  const focusedActual = trendPoints[focusedIndex] ?? 0
+  const focusedDay = focusedPoint?.day ?? 0
+  const monthLengthSafe = Math.max(monthLength, 1)
+  const focusedPace = budget > 0 ? Number(((budget * focusedDay) / monthLengthSafe).toFixed(2)) : null
+  const focusedDelta = focusedPace == null ? null : Number((focusedActual - focusedPace).toFixed(2))
+  const deltaTone = isOverBudget && focusedIndex === lastIndex
+    ? 'danger'
+    : getDeltaTone(focusedActual, focusedPace)
+  const plotHeight = CHART_HEIGHT - CHART_INSET_TOP - CHART_INSET_BOTTOM
+  const midPlotY = CHART_INSET_TOP + plotHeight * 0.4
+  const calloutLeftRaw = (focusedPoint.x / CHART_WIDTH) * 100
+  const calloutLeft = Math.max(4, Math.min(calloutLeftRaw, 96))
+  const calloutNudgeY = 6
+  const placeCalloutBelow = focusedPoint.y < midPlotY
+  const calloutPosition = placeCalloutBelow
+    ? {
+      left: `${calloutLeft}%`,
+      top: `${Math.min(focusedPoint.y + calloutNudgeY, baselineY - 4)}px`,
+      transform: 'translate(-50%, 0)',
+    }
+    : {
+      left: `${calloutLeft}%`,
+      top: `${Math.max(focusedPoint.y - calloutNudgeY, CHART_INSET_TOP + 4)}px`,
+      transform: 'translate(-50%, -100%)',
+    }
+  const isAhead = focusedDelta != null && focusedDelta > 0
+  const isBehind = focusedDelta != null && focusedDelta < 0
+  const deltaLabel = focusedDelta == null
+    ? 'No budget'
+    : Math.abs(focusedDelta) < 0.5
+      ? 'On pace'
+      : isAhead
+        ? `${formatCurrency(Math.abs(focusedDelta))} over pace`
+        : `${formatCurrency(Math.abs(focusedDelta))} under pace`
+  const chartSpendTone = focusedPace == null
+    ? 'neutral'
+    : getDeltaTone(focusedActual, focusedPace)
+  const areaFillId = 'monthPacingFillNeutral'
+
+  function pickIndexFromLocalX(localX) {
+    if (!points.length) return 0
+    let best = 0
+    let bestDist = Infinity
+    for (let i = 0; i < points.length; i += 1) {
+      const d = Math.abs(points[i].x - localX)
+      if (d < bestDist) {
+        bestDist = d
+        best = i
+      }
+    }
+    return best
+  }
+
+  function handlePointerMove(event) {
+    const svg = event.currentTarget
+    const rect = svg.getBoundingClientRect()
+    if (rect.width <= 0) return
+    const localX = ((event.clientX - rect.left) / rect.width) * CHART_WIDTH
+    setHoverIndex(pickIndexFromLocalX(localX))
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHoverIndex((current) => clampIndex((current ?? lastIndex) - 1, points.length))
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHoverIndex((current) => clampIndex((current ?? lastIndex) + 1, points.length))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setHoverIndex(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setHoverIndex(lastIndex)
+    } else if (event.key === 'Escape') {
+      setHoverIndex(null)
+    }
+  }
+
+  const focusedAriaLabel = `Day ${focusedDay}: ${formatCurrency(focusedActual)} cumulative spend${
+    focusedPace != null ? `, pace ${formatCurrency(focusedPace)}, ${deltaLabel.toLowerCase()}` : ''
+  }`
+
+  return (
+    <div
+      className={`month-pacing month-pacing--spend-${chartSpendTone}${isOverBudget ? ' month-pacing--over' : ''}${hoverIndex != null ? ' month-pacing--inspecting' : ''}`}
+    >
+      <div className="month-pacing__frame">
+        <div className="month-pacing__y-axis" aria-hidden="true"></div>
+        <div className="month-pacing__plot">
+          <svg
+            aria-label={focusedAriaLabel}
+            className="month-pacing__svg"
+            onMouseLeave={() => setHoverIndex(null)}
+            onMouseMove={handlePointerMove}
+            onKeyDown={handleKeyDown}
+            onBlur={() => setHoverIndex(null)}
+            preserveAspectRatio="none"
+            role="img"
+            tabIndex={0}
+            viewBox={`0 0 ${CHART_WIDTH} ${CHART_HEIGHT}`}
+          >
+            <defs>
+              <linearGradient id="monthPacingFillPositive" x1="0%" x2="0%" y1="0%" y2="100%">
+                <stop offset="0%" stopColor="rgba(79, 123, 97, 0.38)" />
+                <stop offset="100%" stopColor="rgba(79, 123, 97, 0.04)" />
+              </linearGradient>
+              <linearGradient id="monthPacingFillWarning" x1="0%" x2="0%" y1="0%" y2="100%">
+                <stop offset="0%" stopColor="rgba(201, 130, 90, 0.4)" />
+                <stop offset="100%" stopColor="rgba(201, 130, 90, 0.05)" />
+              </linearGradient>
+              <linearGradient id="monthPacingFillDanger" x1="0%" x2="0%" y1="0%" y2="100%">
+                <stop offset="0%" stopColor="rgba(183, 95, 103, 0.42)" />
+                <stop offset="100%" stopColor="rgba(183, 95, 103, 0.06)" />
+              </linearGradient>
+              <linearGradient id="monthPacingFillNeutral" x1="0%" x2="0%" y1="0%" y2="100%">
+                <stop offset="0%" stopColor="rgba(111, 126, 116, 0.16)" />
+                <stop offset="100%" stopColor="rgba(111, 126, 116, 0.02)" />
+              </linearGradient>
+            </defs>
+            <TrendChartAxes axes={axes} />
+            <path className="month-pacing__area" d={areaPath} fill={`url(#${areaFillId})`} />
+            {segmentedPaths.map((segment, segIndex) => (
+              <path
+                className={`month-pacing__line month-pacing__line--${segment.tone}`}
+                d={segment.d}
+                fill="none"
+                key={`seg-${segIndex}`}
+              />
+            ))}
+            <line
+              className="month-pacing__guide"
+              x1={focusedPoint.x}
+              x2={focusedPoint.x}
+              y1={CHART_INSET_TOP}
+              y2={baselineY}
+            />
+            <circle
+              className={`month-pacing__point${isOverBudget && focusedIndex === lastIndex ? ' month-pacing__point--warning' : ''}`}
+              cx={focusedPoint.x}
+              cy={focusedPoint.y}
+              r="5"
+            />
+          </svg>
+          <div
+            className={`month-pacing__callout month-pacing__callout--${deltaTone}${placeCalloutBelow ? ' month-pacing__callout--below' : ''}`}
+            style={calloutPosition}
+            role="status"
+          >
+            <span className="month-pacing__callout-day">Day {focusedDay}</span>
+            <strong className="month-pacing__callout-value">{formatCurrency(focusedActual)}</strong>
+            <span className="month-pacing__callout-delta">{deltaLabel}</span>
+          </div>
+        </div>
+      </div>
+      <div className="month-pacing__x-axis" aria-hidden="true">
+        <span>Day 1</span>
+        <span>{`Day ${monthLength}`}</span>
+      </div>
+      <div className="month-pacing__snapshot" aria-live="polite">
+        <span className="month-pacing__snapshot-label">Through day {focusedDay}</span>
+        <span className="month-pacing__snapshot-actual">
+          <strong>{formatCurrency(focusedActual)}</strong> actual
+        </span>
+        {focusedPace != null ? (
+          <span className="month-pacing__snapshot-pace">
+            {formatCurrency(focusedPace)} pace · <em>{deltaLabel}</em>
+          </span>
+        ) : (
+          <span className="month-pacing__snapshot-pace">Set a budget to see pace</span>
+        )}
+      </div>
+      <dl className="month-pacing__legend">
+        <div className="month-pacing__legend-item month-pacing__legend-item--actual">
+          <dt>Actual</dt>
+          <dd>{formatCurrency(focusedActual)}</dd>
+        </div>
+        {focusedPace != null ? (
+          <div className="month-pacing__legend-item month-pacing__legend-item--pace">
+            <dt>Pace</dt>
+            <dd>{formatCurrency(focusedPace)}</dd>
+          </div>
+        ) : null}
+        {budget > 0 ? (
+          <div className="month-pacing__legend-item month-pacing__legend-item--budget">
+            <dt>Budget</dt>
+            <dd>{formatCurrency(budget)}</dd>
+          </div>
+        ) : null}
+        {focusedDelta != null ? (
+          <div className={`month-pacing__legend-item month-pacing__legend-item--delta month-pacing__legend-item--${isAhead ? 'over' : isBehind ? 'under' : 'even'}`}>
+            <dt>Status</dt>
+            <dd>{deltaLabel}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </div>
+  )
+}

--- a/nextjs/src/components/ui/PaceVsLastMonthChart.js
+++ b/nextjs/src/components/ui/PaceVsLastMonthChart.js
@@ -1,0 +1,334 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { formatCurrency } from '@/lib/financeUtils'
+
+const VIEW_WIDTH = 320
+const VIEW_HEIGHT = 156
+const INSET_X = 16
+const INSET_TOP = 18
+const INSET_BOTTOM = 26
+
+function toSafeAmount(value) {
+  const amount = Number(value)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+function buildSmoothPath(points = []) {
+  if (!points.length) return ''
+  return points.reduce((path, point, index) => {
+    if (index === 0) return `M ${point.x.toFixed(2)} ${point.y.toFixed(2)}`
+    const previous = points[index - 1]
+    const controlX = (previous.x + point.x) / 2
+    return `${path} C ${controlX.toFixed(2)} ${previous.y.toFixed(2)}, ${controlX.toFixed(2)} ${point.y.toFixed(2)}, ${point.x.toFixed(2)} ${point.y.toFixed(2)}`
+  }, '')
+}
+
+function buildSegmentedSmoothPaths(points, previousPoints) {
+  if (points.length < 2 || !previousPoints.length) {
+    return [{ tone: 'positive', d: buildSmoothPath(points) }]
+  }
+
+  const previousByDay = new Map(previousPoints.map((point) => [point.day, point.amount]))
+  const getTone = (point) => {
+    const previousAmount = previousByDay.get(point.day)
+    if (previousAmount == null) return 'positive'
+    const threshold = Math.max(previousAmount * 0.03, 5)
+    return point.amount > previousAmount + threshold ? 'warning' : 'positive'
+  }
+
+  return points.slice(1).map((point, index) => ({
+    tone: getTone(point),
+    d: buildSmoothPath([points[index], point]),
+  }))
+}
+
+function projectPoints(series, maxDayCount, maxAmount) {
+  if (!series.length || maxDayCount <= 0 || maxAmount <= 0) return []
+  const plotWidth = VIEW_WIDTH - INSET_X * 2
+  const plotHeight = VIEW_HEIGHT - INSET_TOP - INSET_BOTTOM
+  return series.map((item) => {
+    const day = Math.max(1, Math.min(Number(item.day ?? 0), maxDayCount))
+    const amount = toSafeAmount(item.amount)
+    const xRatio = maxDayCount > 1 ? (day - 1) / (maxDayCount - 1) : 0
+    const yRatio = Math.min(amount / maxAmount, 1)
+    return {
+      x: INSET_X + plotWidth * xRatio,
+      y: INSET_TOP + plotHeight * (1 - yRatio),
+      day,
+      amount,
+    }
+  })
+}
+
+function clampIndex(value, length) {
+  if (length <= 0) return 0
+  return Math.max(0, Math.min(value, length - 1))
+}
+
+export default function PaceVsLastMonthChart({
+  currentMonthSeries = [],
+  previousMonthSeries = [],
+  currentMonthLabel = 'This month',
+  previousMonthLabel = 'Last month',
+  monthLength = 31,
+}) {
+  const [hoverIndex, setHoverIndex] = useState(null)
+  const [isPlotActive, setIsPlotActive] = useState(false)
+
+  const hasCurrent = currentMonthSeries.some((item) => toSafeAmount(item?.amount) > 0)
+  const hasPrevious = previousMonthSeries.some((item) => toSafeAmount(item?.amount) > 0)
+
+  const maxDayCount = useMemo(() => Math.max(
+    monthLength,
+    previousMonthSeries.at(-1)?.day ?? 0,
+    currentMonthSeries.at(-1)?.day ?? 0,
+    1,
+  ), [currentMonthSeries, previousMonthSeries, monthLength])
+
+  const maxAmount = useMemo(() => Math.max(
+    ...currentMonthSeries.map((item) => toSafeAmount(item?.amount)),
+    ...previousMonthSeries.map((item) => toSafeAmount(item?.amount)),
+    1,
+  ), [currentMonthSeries, previousMonthSeries])
+
+  const currentPoints = useMemo(
+    () => projectPoints(currentMonthSeries, maxDayCount, maxAmount),
+    [currentMonthSeries, maxDayCount, maxAmount],
+  )
+  const previousPoints = useMemo(
+    () => projectPoints(previousMonthSeries, maxDayCount, maxAmount),
+    [previousMonthSeries, maxDayCount, maxAmount],
+  )
+
+  if (!hasPrevious && !hasCurrent) {
+    return (
+      <div className="pace-chart pace-chart--empty">
+        <strong>Month-over-month pace appears once you have activity to compare.</strong>
+        <span>Add transactions this month and last month to see how your pace compares.</span>
+      </div>
+    )
+  }
+
+  const currentEnd = currentPoints[currentPoints.length - 1] ?? null
+  const lastIndex = (hasCurrent ? currentPoints.length : previousPoints.length) - 1
+  const focusedIndex = hoverIndex == null ? lastIndex : clampIndex(hoverIndex, hasCurrent ? currentPoints.length : previousPoints.length)
+  const focusedDay = (hasCurrent ? currentPoints[focusedIndex] : previousPoints[focusedIndex])?.day ?? 0
+  const focusedCurrent = hasCurrent ? currentPoints[focusedIndex] : null
+  const focusedPrevious = hasPrevious
+    ? previousPoints.find((point) => point.day === focusedDay)
+      ?? previousPoints[focusedDay - 1]
+      ?? previousPoints[previousPoints.length - 1]
+    : null
+  const focusedDelta = focusedCurrent && focusedPrevious
+    ? Number((toSafeAmount(focusedCurrent.amount) - toSafeAmount(focusedPrevious.amount)).toFixed(2))
+    : null
+  const isAhead = focusedDelta != null && focusedDelta > 0
+  const isBehind = focusedDelta != null && focusedDelta < 0
+  const focusedDeltaLabel = focusedDelta == null
+    ? 'No baseline'
+    : Math.abs(focusedDelta) < 0.5
+      ? 'On pace with last month'
+      : isAhead
+        ? `Faster than last month by ${formatCurrency(Math.abs(focusedDelta))}`
+        : `Slower than last month by ${formatCurrency(Math.abs(focusedDelta))}`
+
+  const currentSegments = buildSegmentedSmoothPaths(currentPoints, previousPoints)
+  const previousPath = buildSmoothPath(previousPoints)
+
+  const guideX = focusedCurrent?.x ?? focusedPrevious?.x ?? null
+  const plotPoints = hasCurrent ? currentPoints : previousPoints
+  const calloutLeftRaw = guideX != null ? (guideX / VIEW_WIDTH) * 100 : 50
+  const calloutLeft = Math.max(4, Math.min(calloutLeftRaw, 96))
+  const showCallout = isPlotActive
+  const plotHeight = VIEW_HEIGHT - INSET_TOP - INSET_BOTTOM
+  const midY = INSET_TOP + plotHeight * 0.38
+  const anchorY = focusedCurrent?.y ?? focusedPrevious?.y ?? midY
+  const placeCalloutBelow = anchorY < midY
+  const calloutStyle = placeCalloutBelow
+    ? {
+      left: `${calloutLeft}%`,
+      top: `${Math.min(anchorY + 12, VIEW_HEIGHT - INSET_BOTTOM - 2)}px`,
+      transform: 'translate(-50%, 0)',
+      maxWidth: 'min(200px, 46vw)',
+    }
+    : {
+      left: `${calloutLeft}%`,
+      top: `${Math.max(anchorY - 10, INSET_TOP + 2)}px`,
+      transform: 'translate(-50%, -100%)',
+      maxWidth: 'min(200px, 46vw)',
+    }
+
+  function pickIndexFromLocalX(localX) {
+    const linePoints = plotPoints
+    if (!linePoints.length) return 0
+    if (linePoints.length === 1) return 0
+    let best = 0
+    let bestDist = Infinity
+    for (let i = 0; i < linePoints.length; i += 1) {
+      const d = Math.abs(linePoints[i].x - localX)
+      if (d < bestDist) {
+        bestDist = d
+        best = i
+      }
+    }
+    return best
+  }
+
+  function handlePointerMove(event) {
+    const svg = event.currentTarget
+    const rect = svg.getBoundingClientRect()
+    if (rect.width <= 0) return
+    const localX = ((event.clientX - rect.left) / rect.width) * VIEW_WIDTH
+    const idx = pickIndexFromLocalX(localX)
+    setHoverIndex(idx)
+  }
+
+  function handleKeyDown(event) {
+    if (
+      event.key === 'ArrowLeft'
+      || event.key === 'ArrowDown'
+      || event.key === 'ArrowRight'
+      || event.key === 'ArrowUp'
+      || event.key === 'Home'
+      || event.key === 'End'
+    ) {
+      setIsPlotActive(true)
+    }
+
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowDown') {
+      event.preventDefault()
+      setHoverIndex((current) => clampIndex((current ?? lastIndex) - 1, lastIndex + 1))
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      setHoverIndex((current) => clampIndex((current ?? lastIndex) + 1, lastIndex + 1))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setHoverIndex(0)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setHoverIndex(lastIndex)
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      setHoverIndex(null)
+      setIsPlotActive(false)
+      event.currentTarget.blur()
+    }
+  }
+
+  const ariaLabel = `Cumulative spend ${currentMonthLabel} vs ${previousMonthLabel}. Day ${focusedDay}: ${currentMonthLabel} ${formatCurrency(focusedCurrent?.amount ?? 0)}, ${previousMonthLabel} ${formatCurrency(focusedPrevious?.amount ?? 0)}.`
+
+  return (
+    <div
+      className={`pace-chart${hoverIndex != null ? ' pace-chart--inspecting' : ''}`}
+      data-has-previous={hasPrevious ? 'true' : 'false'}
+    >
+      <div className="pace-chart__legend" role="list">
+        <span className="pace-chart__legend-item pace-chart__legend-item--current" role="listitem">
+          <span className="pace-chart__swatch pace-chart__swatch--current" aria-hidden="true" />
+          {currentMonthLabel}
+        </span>
+        <span className="pace-chart__legend-item pace-chart__legend-item--previous" role="listitem">
+          <span className="pace-chart__swatch pace-chart__swatch--previous" aria-hidden="true" />
+          {previousMonthLabel}
+        </span>
+      </div>
+
+      <div className="pace-chart__default-summary" aria-live="polite">
+        <span className="pace-chart__default-day">Day {focusedDay}</span>
+        <span className="pace-chart__default-current">{currentMonthLabel} <strong>{formatCurrency(focusedCurrent?.amount ?? 0)}</strong></span>
+        {focusedPrevious ? (
+          <span className="pace-chart__default-prev">{previousMonthLabel} {formatCurrency(focusedPrevious.amount)}</span>
+        ) : null}
+        <span className={`pace-chart__default-delta pace-chart__default-delta--${isAhead ? 'ahead' : isBehind ? 'behind' : 'even'}`}>{focusedDeltaLabel}</span>
+      </div>
+
+      <div
+        className="pace-chart__plot"
+        onMouseEnter={() => setIsPlotActive(true)}
+        onMouseLeave={() => {
+          setIsPlotActive(false)
+          setHoverIndex(null)
+        }}
+      >
+        <svg
+          aria-label={ariaLabel}
+          className="pace-chart__svg"
+          onMouseMove={handlePointerMove}
+          onKeyDown={handleKeyDown}
+          onFocus={() => setIsPlotActive(true)}
+          onBlur={() => {
+            setIsPlotActive(false)
+            setHoverIndex(null)
+          }}
+          preserveAspectRatio="none"
+          role="img"
+          tabIndex={0}
+          viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+        >
+          <line
+            className="pace-chart__baseline"
+            x1={INSET_X}
+            x2={VIEW_WIDTH - INSET_X}
+            y1={VIEW_HEIGHT - INSET_BOTTOM}
+            y2={VIEW_HEIGHT - INSET_BOTTOM}
+          />
+
+          {previousPath ? <path className="pace-chart__line pace-chart__line--previous" d={previousPath} /> : null}
+          {currentSegments.map((segment, index) => (
+            segment.d ? (
+              <path
+                className={`pace-chart__line pace-chart__line--current pace-chart__line--current-${segment.tone}`}
+                d={segment.d}
+                key={`current-${index}`}
+              />
+            ) : null
+          ))}
+
+          {currentEnd ? (
+            <line
+              className="pace-chart__today-divider"
+              x1={currentEnd.x}
+              x2={currentEnd.x}
+              y1={INSET_TOP}
+              y2={VIEW_HEIGHT - INSET_BOTTOM}
+            />
+          ) : null}
+
+          {guideX != null ? (
+            <line
+              className="pace-chart__guide"
+              x1={guideX}
+              x2={guideX}
+              y1={INSET_TOP}
+              y2={VIEW_HEIGHT - INSET_BOTTOM}
+            />
+          ) : null}
+
+          {focusedCurrent ? <circle className="pace-chart__point pace-chart__point--current" cx={focusedCurrent.x} cy={focusedCurrent.y} r="4.25" /> : null}
+          {focusedPrevious ? <circle className="pace-chart__point pace-chart__point--previous" cx={focusedPrevious.x} cy={focusedPrevious.y} r="3.5" /> : null}
+        </svg>
+
+        {showCallout ? (
+          <div
+            className={`pace-chart__callout pace-chart__callout--${isAhead ? 'ahead' : isBehind ? 'behind' : 'even'}${placeCalloutBelow ? ' pace-chart__callout--below' : ''}`}
+            style={calloutStyle}
+            role="status"
+          >
+            <span className="pace-chart__callout-day">Day {focusedDay}</span>
+            <strong className="pace-chart__callout-current">{currentMonthLabel} {formatCurrency(focusedCurrent?.amount ?? 0)}</strong>
+            {focusedPrevious ? (
+              <span className="pace-chart__callout-previous">{previousMonthLabel} {formatCurrency(focusedPrevious.amount)}</span>
+            ) : null}
+            <span className="pace-chart__callout-delta">{focusedDeltaLabel}</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="pace-chart__x-axis" aria-hidden="true">
+        <span>Day 1</span>
+        <span>{`Day ${monthLength}`}</span>
+      </div>
+    </div>
+  )
+}

--- a/nextjs/src/components/ui/TransactionDetailSheet.js
+++ b/nextjs/src/components/ui/TransactionDetailSheet.js
@@ -1,0 +1,83 @@
+'use client'
+
+import { getEntryVisual } from '@/lib/financeVisuals'
+import { formatCurrency, formatLongDate } from '@/lib/financeUtils'
+
+export default function TransactionDetailSheet({ entry, onClose, children }) {
+  if (!entry) return null
+
+  const visual = getEntryVisual(entry)
+  const selectedNote = entry.note && entry.note !== entry.chip
+    ? entry.note
+    : entry.kind === 'income'
+      ? 'No note added'
+      : 'Live expense'
+
+  const selectedSubtitle = entry.merchant && entry.merchant !== entry.title
+    ? entry.merchant
+    : entry.note && entry.note !== entry.chip
+      ? entry.note
+      : formatLongDate(entry.occurredOn)
+
+  return (
+    <div className="detail-overlay" role="presentation">
+      <button
+        aria-label="Close transaction details"
+        className="detail-overlay__backdrop"
+        onClick={onClose}
+        type="button"
+      />
+      <div aria-labelledby="transaction-detail-title" aria-modal="true" className={`detail-sheet detail-sheet--${entry.kind}`} role="dialog">
+        <div className="detail-sheet__handle" />
+        <div
+          className={`detail-sheet__hero detail-sheet__hero--${entry.kind}`}
+          style={{
+            '--entry-color': visual.color,
+            '--entry-soft': visual.soft,
+          }}
+        >
+          <span className={`detail-sheet__tone-band detail-sheet__tone-band--${entry.kind}`} aria-hidden="true" />
+          <div className="entry-avatar entry-avatar--large">
+            <span>{visual.symbol}</span>
+          </div>
+          <div className="detail-sheet__copy">
+            <span className="entry-chip">{entry.kind === 'income' ? 'Income' : 'Expense'}</span>
+            <h2 className="detail-sheet__title" id="transaction-detail-title">{entry.title}</h2>
+            <p className="detail-sheet__subtitle">{selectedSubtitle}</p>
+          </div>
+          <button className="button-secondary page-retry" onClick={onClose} type="button">
+            Close
+          </button>
+        </div>
+
+        <div className="detail-sheet__amount">
+          <span className={`entry-amount entry-amount--${entry.kind}`}>
+            {entry.kind === 'income' ? '+' : '-'}
+            {formatCurrency(entry.amount)}
+          </span>
+        </div>
+
+        <div className="detail-grid">
+          <div>
+            <span>Category</span>
+            <strong>{entry.chip}</strong>
+          </div>
+          <div>
+            <span>Date</span>
+            <strong>{formatLongDate(entry.occurredOn)}</strong>
+          </div>
+          <div>
+            <span>Type</span>
+            <strong>{entry.kind === 'income' ? 'Income' : 'Expense'}</strong>
+          </div>
+          <div>
+            <span>Note</span>
+            <strong>{selectedNote}</strong>
+          </div>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/nextjs/src/components/ui/TrendChartAxes.js
+++ b/nextjs/src/components/ui/TrendChartAxes.js
@@ -1,0 +1,34 @@
+'use client'
+
+export default function TrendChartAxes({ axes }) {
+  if (!axes) return null
+  const { paceLine, budgetLineY, budgetLineLabel, plotLeft, plotRight } = axes
+  const labelX = (plotRight ?? 0) - 4
+  const labelY = budgetLineY != null ? budgetLineY - 5 : 0
+
+  return (
+    <g aria-hidden="true" className="trend-chart__axes">
+      {budgetLineY != null ? (
+        <line
+          className="trend-chart__budget-line"
+          x1={plotLeft}
+          x2={plotRight}
+          y1={budgetLineY}
+          y2={budgetLineY}
+        />
+      ) : null}
+
+      {/* budgetLineLabel removed to avoid visual clutter */}
+
+      {paceLine ? (
+        <line
+          className="trend-chart__pace-line"
+          x1={paceLine.startX}
+          x2={paceLine.endX}
+          y1={paceLine.startY}
+          y2={paceLine.endY}
+        />
+      ) : null}
+    </g>
+  )
+}

--- a/nextjs/src/lib/budgetHealth.js
+++ b/nextjs/src/lib/budgetHealth.js
@@ -1,6 +1,7 @@
 import { formatCurrency, getCurrentMonthStart } from './financeUtils'
 
 export const BUDGET_NEAR_LIMIT_RATIO = 0.8
+export const BUDGET_WATCH_RATIO = 0.6
 
 function getSafeMoneyNumber(value) {
   if (value == null || value === '') return null
@@ -371,6 +372,19 @@ export function buildCategoryBudgetHealth({
     }
   }
 
+  if (spentAmount >= limit * BUDGET_WATCH_RATIO) {
+    return {
+      key: 'watch',
+      label: 'Watch',
+      tone: 'caution',
+      progressPercentage,
+      remainingAmount,
+      remainingText: formatMoneyDelta(remainingAmount),
+      detailText,
+      ariaValueText: `${Math.round(progressPercentage)} percent used, ${formatMoneyDelta(remainingAmount)}.`,
+    }
+  }
+
   return {
     key: 'on_track',
     label: 'On track',
@@ -393,6 +407,8 @@ export function buildBudgetPressureHighlight({
       .map((item) => ({
         name: item?.category_name || 'Uncategorized',
         progress: getSafeMoneyNumber(item?.progress_percentage) ?? 0,
+        monthlyLimit: getSafeMoneyNumber(item?.monthly_limit),
+        spent: getSafeMoneyNumber(item?.spent),
         health: buildCategoryBudgetHealth({
           monthlyLimit: item?.monthly_limit,
           spent: item?.spent,
@@ -412,6 +428,10 @@ export function buildBudgetPressureHighlight({
       tone: 'danger',
       title: overspentStatus.name,
       detail: `${formatCurrency(Math.abs(overspentStatus.health.remainingAmount))} over budget right now.`,
+      progressPercentage: Math.min(Number(overspentStatus.health.progressPercentage ?? overspentStatus.progress ?? 100), 100),
+      monthlyLimit: overspentStatus.monthlyLimit,
+      remainingAmount: overspentStatus.health.remainingAmount,
+      spent: overspentStatus.spent,
     }
   }
 
@@ -428,6 +448,10 @@ export function buildBudgetPressureHighlight({
       tone: highestPressure.health.tone,
       title: highestPressure.name,
       detail: `${Math.round(highestPressure.progress)}% used with ${highestPressure.health.remainingText}.`,
+      progressPercentage: Math.min(Number(highestPressure.progress ?? 0), 100),
+      monthlyLimit: highestPressure.monthlyLimit,
+      remainingAmount: highestPressure.health.remainingAmount,
+      spent: highestPressure.spent,
     }
   }
 
@@ -438,6 +462,10 @@ export function buildBudgetPressureHighlight({
       tone: 'neutral',
       title: fallbackSpendCards[0].name,
       detail: `${fallbackSpendCards[0].note} this month.`,
+      progressPercentage: Math.min(Number(fallbackSpendCards[0].progress ?? 0), 100),
+      monthlyLimit: null,
+      remainingAmount: null,
+      spent: fallbackSpendCards[0].amount ?? null,
     }
   }
 
@@ -447,5 +475,9 @@ export function buildBudgetPressureHighlight({
     tone: 'neutral',
     title: 'Waiting on categories',
     detail: 'Current-month category pressure will show once expenses land.',
+    progressPercentage: 0,
+    monthlyLimit: null,
+    remainingAmount: null,
+    spent: null,
   }
 }

--- a/nextjs/src/lib/demoData.js
+++ b/nextjs/src/lib/demoData.js
@@ -286,4 +286,27 @@ export const demoInsightsSnapshot = {
     { id: 'demo-exp-6', amount: 89.5, title: "Trader Joe's", categoryName: 'Groceries', occurredOn: '2026-03-21', color: '#6faa80', soft: 'rgba(111, 170, 128, 0.18)', symbol: '\u{1F6D2}' },
     { id: 'demo-exp-1', amount: 80, title: 'Target run', categoryName: 'Shopping', occurredOn: '2026-03-29', color: '#c9869e', soft: 'rgba(201, 134, 158, 0.18)', symbol: '\u{1F6CD}\uFE0F' },
   ],
+  previousDailySpend: {
+    totalAmount: 934.18,
+    averageAmount: 33.36,
+    activeDayAverage: 103.8,
+    peakDay: { day: 26, key: '2026-02-26', amount: 220.4 },
+    activeDays: 9,
+    series: [
+      { day: 1, key: '2026-02-01', amount: 0 }, { day: 2, key: '2026-02-02', amount: 0 }, { day: 3, key: '2026-02-03', amount: 0 }, { day: 4, key: '2026-02-04', amount: 0 }, { day: 5, key: '2026-02-05', amount: 0 }, { day: 6, key: '2026-02-06', amount: 0 }, { day: 7, key: '2026-02-07', amount: 0 }, { day: 8, key: '2026-02-08', amount: 0 }, { day: 9, key: '2026-02-09', amount: 0 }, { day: 10, key: '2026-02-10', amount: 0 }, { day: 11, key: '2026-02-11', amount: 0 }, { day: 12, key: '2026-02-12', amount: 42.5 }, { day: 13, key: '2026-02-13', amount: 0 }, { day: 14, key: '2026-02-14', amount: 0 }, { day: 15, key: '2026-02-15', amount: 78 }, { day: 16, key: '2026-02-16', amount: 0 }, { day: 17, key: '2026-02-17', amount: 112.3 }, { day: 18, key: '2026-02-18', amount: 0 }, { day: 19, key: '2026-02-19', amount: 65.8 }, { day: 20, key: '2026-02-20', amount: 0 }, { day: 21, key: '2026-02-21', amount: 0 }, { day: 22, key: '2026-02-22', amount: 98.2 }, { day: 23, key: '2026-02-23', amount: 0 }, { day: 24, key: '2026-02-24', amount: 52 }, { day: 25, key: '2026-02-25', amount: 0 }, { day: 26, key: '2026-02-26', amount: 220.4 }, { day: 27, key: '2026-02-27', amount: 0 }, { day: 28, key: '2026-02-28', amount: 264.98 },
+    ],
+    details: [
+      { id: 'demo-prev-1', key: '2026-02-12', amount: 42.5, title: 'Cafeteria refill', categoryName: 'Dining', occurredOn: '2026-02-12', color: '#d29e4a', soft: 'rgba(210, 158, 74, 0.18)', symbol: '\u{1F37D}\uFE0F' },
+      { id: 'demo-prev-2', key: '2026-02-15', amount: 78, title: 'Trader Joe\'s', categoryName: 'Groceries', occurredOn: '2026-02-15', color: '#6faa80', soft: 'rgba(111, 170, 128, 0.18)', symbol: '\u{1F6D2}' },
+      { id: 'demo-prev-3', key: '2026-02-17', amount: 112.3, title: 'Amazon (mug + book)', categoryName: 'Shopping', occurredOn: '2026-02-17', color: '#c9869e', soft: 'rgba(201, 134, 158, 0.18)', symbol: '\u{1F6CD}\uFE0F' },
+      { id: 'demo-prev-4', key: '2026-02-19', amount: 65.8, title: 'Concert ticket', categoryName: 'Fun', occurredOn: '2026-02-19', color: '#8d7fd1', soft: 'rgba(141, 127, 209, 0.18)', symbol: '\u{1F3AE}' },
+      { id: 'demo-prev-5', key: '2026-02-22', amount: 98.2, title: 'JetBlue baggage', categoryName: 'Travel', occurredOn: '2026-02-22', color: '#62a9b7', soft: 'rgba(98, 169, 183, 0.18)', symbol: '\u2708\uFE0F' },
+      { id: 'demo-prev-6', key: '2026-02-24', amount: 52, title: 'Pharmacy run', categoryName: 'Health', occurredOn: '2026-02-24', color: '#63a6cf', soft: 'rgba(99, 166, 207, 0.18)', symbol: '\u2695\uFE0F' },
+      { id: 'demo-prev-7', key: '2026-02-26', amount: 158.8, title: 'Whole Foods big haul', categoryName: 'Groceries', occurredOn: '2026-02-26', color: '#6faa80', soft: 'rgba(111, 170, 128, 0.18)', symbol: '\u{1F6D2}' },
+      { id: 'demo-prev-8', key: '2026-02-26', amount: 61.6, title: 'Target essentials', categoryName: 'Shopping', occurredOn: '2026-02-26', color: '#c9869e', soft: 'rgba(201, 134, 158, 0.18)', symbol: '\u{1F6CD}\uFE0F' },
+      { id: 'demo-prev-9', key: '2026-02-28', amount: 145, title: 'Costco haul', categoryName: 'Groceries', occurredOn: '2026-02-28', color: '#6faa80', soft: 'rgba(111, 170, 128, 0.18)', symbol: '\u{1F6D2}' },
+      { id: 'demo-prev-10', key: '2026-02-28', amount: 96.7, title: 'Apple keyboard', categoryName: 'Shopping', occurredOn: '2026-02-28', color: '#c9869e', soft: 'rgba(201, 134, 158, 0.18)', symbol: '\u{1F6CD}\uFE0F' },
+      { id: 'demo-prev-11', key: '2026-02-28', amount: 23.28, title: 'Late dinner', categoryName: 'Dining', occurredOn: '2026-02-28', color: '#d29e4a', soft: 'rgba(210, 158, 74, 0.18)', symbol: '\u{1F37D}\uFE0F' },
+    ],
+  },
 }

--- a/nextjs/src/lib/financeUtils.js
+++ b/nextjs/src/lib/financeUtils.js
@@ -1,4 +1,4 @@
-import { getCategoryLabel } from './financeVisuals'
+import { getCategoryLabel, getCategoryVisual } from './financeVisuals'
 
 const currencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -197,7 +197,7 @@ export function buildActivityFeed(expenses = [], income = []) {
   const expenseEntries = expenses.map((expense) => {
     const categoryName = expense?.category_name || 'Expense'
     const description = expense?.description?.trim()
-    const displayCategory = getCategoryLabel([categoryName, description].filter(Boolean).join(' '), 'expense')
+    const displayCategory = getCategoryLabel(categoryName, 'expense')
 
     return {
       id: `expense-${expense.id}`,
@@ -238,6 +238,67 @@ export function buildActivityFeed(expenses = [], income = []) {
   ))
 }
 
+function toAmountDetail(value) {
+  const amount = Number(value ?? 0)
+  return Number.isFinite(amount) ? Number(amount.toFixed(2)) : 0
+}
+
+function buildDailyExpenseDetailId(row, dayKey, fallbackOrdinalByKey) {
+  if (row.id != null && row.id !== '') {
+    return String(row.id)
+  }
+  const amount = toAmountDetail(row.amount)
+  const title = String(row.title ?? row.description ?? '').trim()
+  const category = String(row.category_name ?? '').trim()
+  const dedupeKey = `${dayKey}\t${amount}\t${title}\t${category}`
+  const ordinal = (fallbackOrdinalByKey.get(dedupeKey) ?? 0) + 1
+  fallbackOrdinalByKey.set(dedupeKey, ordinal)
+  const ordinalSuffix = ordinal > 1 ? `:${ordinal}` : ''
+  return `daily-expense-fallback:${dayKey}:${amount}:${title}:${category}${ordinalSuffix}`
+}
+
+/** Maps API expense rows to the detail entries consumed by CategoryTransactionsModal (client-only; avoids importing server insights bundle). */
+export function buildDailySpendDetailsFromExpenses(rows = []) {
+  const grouped = new Map()
+  const fallbackOrdinalByKey = new Map()
+
+  rows.forEach((row, index) => {
+    const dateValue = row.date || row.created_at || row.occurred_on
+    const key = toDayKey(dateValue)
+    if (!key || key === 'unknown') return
+
+    const description = row.description != null ? String(row.description).trim() : ''
+    const categorySeed = row.category_name || description || `Expense ${index + 1}`
+    const visual = getCategoryVisual(categorySeed)
+    const title = description || row.category_name || visual.label
+
+    const nextEntry = {
+      id: buildDailyExpenseDetailId(row, key, fallbackOrdinalByKey),
+      key,
+      amount: toAmountDetail(row.amount),
+      title,
+      categoryName: visual.label,
+      occurredOn: key,
+      color: visual.color,
+      soft: visual.soft,
+      symbol: row.category_icon || visual.symbol,
+    }
+
+    if (!grouped.has(key)) grouped.set(key, [])
+    grouped.get(key).push(nextEntry)
+  })
+
+  return Array.from(grouped.entries()).flatMap(([key, entries]) =>
+    entries
+      .sort((left, right) => {
+        const amountDifference = right.amount - left.amount
+        if (amountDifference !== 0) return amountDifference
+        return String(left.title || '').localeCompare(String(right.title || ''))
+      })
+      .map((entry) => ({ ...entry, key })),
+  )
+}
+
 export function groupActivityByDate(entries = []) {
   const groups = new Map()
 
@@ -270,4 +331,154 @@ export function buildIncomeSourceBreakdown(incomeEntries = [], month) {
   return Array.from(grouped.entries())
     .map(([name, amount]) => ({ name, amount }))
     .sort((left, right) => right.amount - left.amount)
+}
+
+function getMonthShortLabel(value) {
+  const date = parseCalendarDate(value)
+  if (!date) return ''
+  return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })
+}
+
+export function buildRecentCashFlow(expenses = [], income = [], month, monthsBack = 3) {
+  const anchorMonth = getMonthStartValue(month)
+  if (!anchorMonth) return []
+
+  const safeMonthsBack = Math.max(1, Number(monthsBack) || 3)
+
+  const monthKeys = []
+  for (let offset = safeMonthsBack - 1; offset >= 0; offset -= 1) {
+    const shifted = shiftMonth(anchorMonth, -offset)
+    if (shifted) monthKeys.push(shifted)
+  }
+
+  const totalsByMonth = new Map(monthKeys.map((key) => [key, { incomeAmount: 0, expenseAmount: 0 }]))
+
+  const addEntry = (entry, kind) => {
+    const key = getMonthStartValue(entry?.date || entry?.created_at)
+    if (!key || !totalsByMonth.has(key)) return
+    const bucket = totalsByMonth.get(key)
+    const amount = Number(entry?.amount ?? 0)
+    if (!Number.isFinite(amount)) return
+    if (kind === 'income') bucket.incomeAmount += amount
+    else bucket.expenseAmount += amount
+  }
+
+  income.forEach((entry) => addEntry(entry, 'income'))
+  expenses.forEach((entry) => addEntry(entry, 'expense'))
+
+  return monthKeys.map((key) => {
+    const bucket = totalsByMonth.get(key) || { incomeAmount: 0, expenseAmount: 0 }
+    const incomeAmount = Number(bucket.incomeAmount.toFixed(2))
+    const expenseAmount = Number(bucket.expenseAmount.toFixed(2))
+    const netAmount = Number((incomeAmount - expenseAmount).toFixed(2))
+    return {
+      month: key,
+      label: getMonthShortLabel(key),
+      incomeAmount,
+      expenseAmount,
+      netAmount,
+    }
+  })
+}
+
+export function buildCumulativeDailyTotals(expenses = [], month) {
+  const monthDate = parseCalendarDate(month)
+  if (!monthDate) return []
+
+  const year = monthDate.getUTCFullYear()
+  const monthIndex = monthDate.getUTCMonth()
+  const monthLength = new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate()
+  const totalsByDay = Array.from({ length: monthLength }, () => 0)
+
+  expenses
+    .filter((expense) => isInMonth(expense.date || expense.created_at, month))
+    .forEach((expense) => {
+      const entryDate = parseCalendarDate(expense.date || expense.created_at)
+      if (!entryDate) return
+
+      const dayIndex = entryDate.getUTCDate() - 1
+      if (dayIndex < 0 || dayIndex >= totalsByDay.length) return
+      const amount = Number(expense.amount ?? 0)
+      if (Number.isFinite(amount)) totalsByDay[dayIndex] += amount
+    })
+
+  let running = 0
+  return totalsByDay.map((amount, index) => {
+    running += amount
+    return {
+      day: index + 1,
+      amount: Number(running.toFixed(2)),
+    }
+  })
+}
+
+export function buildTrendChartAxes({
+  budget,
+  monthLength,
+  activeDay,
+  pointCount,
+  width,
+  height,
+  inset,
+  insetTop,
+  insetBottom,
+  valueCeiling,
+}) {
+  const safeMonthLength = Math.max(0, Number(monthLength) || 0)
+  const safeActiveDay = Math.max(0, Math.min(Number(activeDay) || 0, safeMonthLength))
+  const safePointCount = Math.max(0, Math.floor(Number(pointCount) || 0))
+  const safeWidth = Math.max(0, Number(width) || 0)
+  const safeHeight = Math.max(0, Number(height) || 0)
+  const safeInset = Math.max(0, Number(inset) || 0)
+  const safeBudget = Number(budget) > 0 ? Number(budget) : 0
+  const top = insetTop ?? safeInset
+  const bottom = insetBottom ?? safeInset
+
+  const plotWidth = Math.max(safeWidth - safeInset * 2, 0)
+  const plotHeight = Math.max(safeHeight - top - bottom, 0)
+  const scaleMaxRaw = valueCeiling != null && Number(valueCeiling) > 0 ? Number(valueCeiling) : null
+  const scaleMax = scaleMaxRaw != null ? scaleMaxRaw : (safeBudget > 0 ? safeBudget : 1)
+
+  const buildPoint = (progressRatio, valueRatio) => ({
+    x: safeInset + plotWidth * progressRatio,
+    y: top + plotHeight * (1 - valueRatio),
+  })
+
+  const paceLine = safeBudget > 0 && safeMonthLength > 0 && safePointCount >= 2
+    ? (() => {
+      const start = buildPoint(0, 0)
+      const finalProgress = Math.min(Math.max(safePointCount - 1, 0) / Math.max(safePointCount - 1, 1), 1)
+      const finalDayIndex = Math.min(safePointCount, safeMonthLength)
+      const finalPaceValue = (safeBudget * finalDayIndex) / safeMonthLength
+      const paceRatio = Math.min(finalPaceValue / scaleMax, 1)
+      return {
+        startX: start.x,
+        startY: start.y,
+        endX: safeInset + plotWidth * finalProgress,
+        endY: top + plotHeight * (1 - paceRatio),
+      }
+    })()
+    : null
+
+  const budgetLineY = safeBudget > 0
+    ? top + plotHeight * (1 - Math.min(safeBudget / scaleMax, 1))
+    : null
+
+  const axisLabels = safeBudget > 0
+    ? [
+      { y: top + plotHeight, value: 0 },
+      { y: top, value: scaleMax },
+    ]
+    : null
+
+  const budgetLineLabel = safeBudget > 0 ? formatCurrency(safeBudget) : null
+
+  return {
+    paceLine,
+    budgetLineY,
+    budgetLineLabel,
+    axisLabels,
+    plotLeft: safeInset,
+    plotRight: safeWidth - safeInset,
+  }
 }

--- a/nextjs/src/lib/financeVisuals.js
+++ b/nextjs/src/lib/financeVisuals.js
@@ -164,6 +164,14 @@ export function getCategoryVisual(value, kind = 'expense') {
 }
 
 export function getEntryVisual(entry) {
+  if (entry?.chip) {
+    return getCategoryVisual(entry.chip, entry?.kind)
+  }
+
+  if (entry?.categoryName) {
+    return getCategoryVisual(entry.categoryName, entry?.kind)
+  }
+
   return getCategoryVisual(
     [entry?.chip, entry?.merchant, entry?.title, entry?.note].filter(Boolean).join(' '),
     entry?.kind

--- a/nextjs/src/lib/insights.js
+++ b/nextjs/src/lib/insights.js
@@ -587,6 +587,8 @@ export async function buildInsightsSnapshot(userId, month) {
     dailyExpenseTotals,
     dailyExpenseEntries,
     topExpenses,
+    previousDailyExpenseTotals,
+    previousDailyExpenseEntries,
   ] = await Promise.all([
     buildBudgetSummary(userId, month),
     previousMonth ? buildBudgetSummary(userId, previousMonth) : Promise.resolve(null),
@@ -597,6 +599,8 @@ export async function buildInsightsSnapshot(userId, month) {
     getDailyExpenseTotals(userId, month),
     getDailyExpenseEntries(userId, month),
     getTopExpenses(userId, month),
+    previousMonth ? getDailyExpenseTotals(userId, previousMonth) : Promise.resolve([]),
+    previousMonth ? getDailyExpenseEntries(userId, previousMonth) : Promise.resolve([]),
   ])
 
   const cashFlow = buildCashFlowSeries(monthWindow, monthlyExpenseTotals, monthlyIncomeTotals)
@@ -604,6 +608,12 @@ export async function buildInsightsSnapshot(userId, month) {
     ...buildDailySpendSeries(dailyExpenseTotals, month),
     details: buildDailySpendDetails(dailyExpenseEntries),
   }
+  const previousDailySpend = previousMonth
+    ? {
+      ...buildDailySpendSeries(previousDailyExpenseTotals, previousMonth),
+      details: buildDailySpendDetails(previousDailyExpenseEntries),
+    }
+    : { series: [], totalAmount: 0, averageAmount: 0, activeDayAverage: 0, peakDay: null, activeDays: 0, details: [] }
   const categoryMovers = buildCategoryMovers(summary?.category_statuses, previousSummary?.category_statuses)
   const budgetHealth = buildBudgetHealth(summary)
 
@@ -620,6 +630,7 @@ export async function buildInsightsSnapshot(userId, month) {
     categoryMovers,
     budgetHealth,
     dailySpend,
+    previousDailySpend,
     topExpenses,
   }
 }


### PR DESCRIPTION
## Description
Polishes the Dashboard, Insights, and Transactions presentation for Issue #59.
This pass improves visual hierarchy, chart readability, and category-progress presentation by flattening the Dashboard hero, standardizing shared UI primitives, improving pacing/cash-flow/category visuals, and adding focused drill-down/detail interactions. It also adds and updates frontend coverage for the new UI components and budget-health states, including a new “watch” threshold.

## Related User Story / Issue

Fixes #59

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [x] Refactor

## How Has This Been Tested?

- [ ] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes

Local verification:
- `npx jest --no-coverage` — 28 suites / 307 tests passed
- `npm run build` — production build succeeded
- Manual browser review of Dashboard, Insights, Planner, and Transactions

## UI Changes (if applicable)

- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Screenshots (if UI changed)
<img width="1032" height="1769" alt="image" src="https://github.com/user-attachments/assets/073d4681-af44-48c0-9798-c1de3a10883c" />
<img width="1021" height="698" alt="image" src="https://github.com/user-attachments/assets/52b484d5-00e7-4da1-9807-794869319528" />
<img width="1020" height="1762" alt="image" src="https://github.com/user-attachments/assets/a59a5fa5-4224-4ff2-9243-ad44bff26e3b" />
<img width="1032" height="1771" alt="image" src="https://github.com/user-attachments/assets/93a08a53-49ad-4c41-b144-3fa4bd503097" />
<img width="1038" height="1766" alt="image" src="https://github.com/user-attachments/assets/90516ec9-a4fc-4a0e-ad33-14637ed5acb9" />
<img width="1021" height="1619" alt="image" src="https://github.com/user-attachments/assets/bd57be74-7ed3-46b6-93ca-d48051db6a6a" />


## Notes for Reviewers

- Large UI/CSS polish pass scoped to Issue #59.
- Adds shared UI primitives for allocation bars, category progress rows, pacing charts, financial health, cash-flow snapshots, transaction detail display, and category drill-downs.
- Most new styling is scoped to the Issue #59 section/classes in `nextjs/src/app/globals.css`.
- Adds a new `watch` budget health threshold at `0.6` to support softer warning states before near-limit/over-budget states.
- No package, CI, auth, Planner, or release-workflow changes are intended in this PR.

Follow-up polish that may be worth a separate issue/PR:
- The Transactions floating `+` button can overlap the bottom nav at some viewport sizes and should be repositioned or made nav-aware. Did not fix that in this PR. 
- Planner could eventually reuse the Insights-style month modal / month switcher interaction.
- The month-view modal could support previous/next month navigation.
- Some chart/status color tuning may still be refined later, but this PR establishes the shared visual primitives and consistency layer.

## Checklist

- [x] Linked to a user story or issue
- [x] Code builds / tests pass locally
- [x] Ready for review