### PR TITLE
Fix savings goals test month flake after April rollover

### DIFF
--- a/nextjs/__tests__/savings-goals.test.js
+++ b/nextjs/__tests__/savings-goals.test.js
@@ -149,6 +149,7 @@ describe('GET /api/savings-goals', () => {
 
     await testApiHandler({
       appHandler: goalsHandler,
+      url: 'http://localhost/api/savings-goals?month=2026-04',
       async test({ fetch }) {
         const res = await fetch()
         expect(res.status).toBe(200)


### PR DESCRIPTION
## Description
Makes the savings goals API test deterministic by requesting the intended April 2026 budget context explicitly. The route still defaults to the current month in production; only the brittle test assumption changed.

## Related User Story / Issue
Follow-up to #76

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Backend / API change
- [ ] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [x] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes
Verified locally:
- `npm test -- --runTestsByPath __tests__/savings-goals.test.js --runInBand`
- `npm test -- --runInBand`
- `npm run build`

## UI Changes (if applicable)
- [x] No UI changes
- [ ] UI updated (add screenshots if needed)

## Notes for Reviewers
This does not change production behavior. The failing test was asserting April 2026 while making a request without `month`, so it began receiving May 2026 once the runner date moved into May.

## Checklist
- [x] Linked to a user story or issue
- [x] Code builds / tests pass in CI
- [x] Ready for review