### PR TITLE
Add Signed-Out Demo Flow

### DIFF
--- a/nextjs/__tests__/frontend/accountPage.unit.test.js
+++ b/nextjs/__tests__/frontend/accountPage.unit.test.js
@@ -1,5 +1,4 @@
 /** @jest-environment jsdom */
-// Source: src/app/(app)/account/page.js
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({ replace: jest.fn(), push: jest.fn() })),

--- a/nextjs/__tests__/frontend/accountPage.unit.test.js
+++ b/nextjs/__tests__/frontend/accountPage.unit.test.js
@@ -2,7 +2,7 @@
 // Source: src/app/(app)/account/page.js
 
 jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(() => ({ replace: jest.fn() })),
+  useRouter: jest.fn(() => ({ replace: jest.fn(), push: jest.fn() })),
 }))
 
 jest.mock('@/components/providers', () => ({
@@ -26,7 +26,7 @@ const AccountPage = require('@/app/(app)/account/page').default
 
 function setup({ email = 'john.doe@example.com', theme = 'light', mode = 'live' } = {}) {
   const mockReplace = jest.fn()
-  useRouter.mockReturnValue({ replace: mockReplace })
+  useRouter.mockReturnValue({ replace: mockReplace, push: jest.fn() })
   useAuth.mockReturnValue({ user: email ? { email } : {}, logout: jest.fn() })
   useDataMode.mockReturnValue({ mode, isSampleMode: mode === 'sample', setMode: jest.fn() })
   useTheme.mockReturnValue({ theme, setTheme: jest.fn() })
@@ -51,7 +51,6 @@ describe('AccountPage — display name and initials', () => {
     await act(async () => { render(React.createElement(AccountPage)) })
     expect(screen.getByText('test@example.com')).toBeTruthy()
   })
-
 })
 
 describe('AccountPage — theme controls', () => {
@@ -63,7 +62,7 @@ describe('AccountPage — theme controls', () => {
 
   it('calls setTheme("dark") when Dark button is clicked', async () => {
     const setTheme = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn() })
+    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
     useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout: jest.fn() })
     useDataMode.mockReturnValue({ mode: 'live', isSampleMode: false, setMode: jest.fn() })
     useTheme.mockReturnValue({ theme: 'light', setTheme })
@@ -74,7 +73,7 @@ describe('AccountPage — theme controls', () => {
 
   it('calls setTheme("light") when Light button is clicked', async () => {
     const setTheme = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn() })
+    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
     useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout: jest.fn() })
     useDataMode.mockReturnValue({ mode: 'live', isSampleMode: false, setMode: jest.fn() })
     useTheme.mockReturnValue({ theme: 'dark', setTheme })
@@ -93,7 +92,7 @@ describe('AccountPage — data mode controls', () => {
 
   it('calls setMode("sample") when Sample button is clicked', async () => {
     const setMode = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn() })
+    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
     useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout: jest.fn() })
     useDataMode.mockReturnValue({ mode: 'live', isSampleMode: false, setMode })
     useTheme.mockReturnValue({ theme: 'light', setTheme: jest.fn() })
@@ -104,7 +103,7 @@ describe('AccountPage — data mode controls', () => {
 
   it('calls setMode("live") when Live button is clicked', async () => {
     const setMode = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn() })
+    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
     useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout: jest.fn() })
     useDataMode.mockReturnValue({ mode: 'sample', isSampleMode: true, setMode })
     useTheme.mockReturnValue({ theme: 'light', setTheme: jest.fn() })
@@ -118,7 +117,7 @@ describe('AccountPage — logout', () => {
   it('logout button calls logout and router.replace("/login")', async () => {
     const logout = jest.fn()
     const mockReplace = jest.fn()
-    useRouter.mockReturnValue({ replace: mockReplace })
+    useRouter.mockReturnValue({ replace: mockReplace, push: jest.fn() })
     useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout })
     useDataMode.mockReturnValue({ mode: 'live', isSampleMode: false, setMode: jest.fn() })
     useTheme.mockReturnValue({ theme: 'light', setTheme: jest.fn() })
@@ -130,7 +129,7 @@ describe('AccountPage — logout', () => {
 
   it('logout button shows "Signing you out..." and becomes disabled when clicked', async () => {
     const logout = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn() })
+    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
     useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout })
     useDataMode.mockReturnValue({ mode: 'live', isSampleMode: false, setMode: jest.fn() })
     useTheme.mockReturnValue({ theme: 'light', setTheme: jest.fn() })
@@ -139,3 +138,4 @@ describe('AccountPage — logout', () => {
     expect(screen.getByRole('button', { name: /signing you out/i }).disabled).toBe(true)
   })
 })
+

--- a/nextjs/__tests__/frontend/accountPage.unit.test.js
+++ b/nextjs/__tests__/frontend/accountPage.unit.test.js
@@ -82,36 +82,6 @@ describe('AccountPage — theme controls', () => {
   })
 })
 
-describe('AccountPage — data mode controls', () => {
-  it('shows "Sample data" copy when mode is sample', async () => {
-    setup({ mode: 'sample' })
-    await act(async () => { render(React.createElement(AccountPage)) })
-    expect(screen.getByText(/sample data — exploring/i)).toBeTruthy()
-  })
-
-  it('calls setMode("sample") when Sample button is clicked', async () => {
-    const setMode = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
-    useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout: jest.fn() })
-    useDataMode.mockReturnValue({ mode: 'live', isSampleMode: false, setMode })
-    useTheme.mockReturnValue({ theme: 'light', setTheme: jest.fn() })
-    await act(async () => { render(React.createElement(AccountPage)) })
-    fireEvent.click(screen.getByRole('button', { name: /^sample$/i }))
-    expect(setMode).toHaveBeenCalledWith('sample')
-  })
-
-  it('calls setMode("live") when Live button is clicked', async () => {
-    const setMode = jest.fn()
-    useRouter.mockReturnValue({ replace: jest.fn(), push: jest.fn() })
-    useAuth.mockReturnValue({ user: { email: 'a@b.com' }, logout: jest.fn() })
-    useDataMode.mockReturnValue({ mode: 'sample', isSampleMode: true, setMode })
-    useTheme.mockReturnValue({ theme: 'light', setTheme: jest.fn() })
-    await act(async () => { render(React.createElement(AccountPage)) })
-    fireEvent.click(screen.getByRole('button', { name: /^live$/i }))
-    expect(setMode).toHaveBeenCalledWith('live')
-  })
-})
-
 describe('AccountPage — logout', () => {
   it('logout button calls logout and router.replace("/login")', async () => {
     const logout = jest.fn()

--- a/nextjs/__tests__/frontend/appLayout.unit.test.js
+++ b/nextjs/__tests__/frontend/appLayout.unit.test.js
@@ -1,0 +1,141 @@
+/** @jest-environment jsdom */
+// Source: src/app/(app)/layout.js
+//
+// Tests focus on the three guard behaviours:
+//   1. Show loading shell when not ready and not authenticated (live mode)
+//   2. Redirect to /login when ready but unauthenticated (live mode)
+//   3. Skip the guard entirely in demo/sample mode — render children immediately
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+}))
+
+jest.mock('@/components/providers', () => ({
+  useAuth: jest.fn(),
+  useDataMode: jest.fn(),
+}))
+
+// Stub next/link so it renders a plain <a> — keeps the DOM simple
+jest.mock('next/link', () => {
+  const React = require('react')
+  return function MockLink({ href, children, ...rest }) {
+    return React.createElement('a', { href, ...rest }, children)
+  }
+})
+
+const React = require('react')
+const { render, screen, act } = require('@testing-library/react')
+const { useRouter, usePathname } = require('next/navigation')
+const { useAuth, useDataMode } = require('@/components/providers')
+const AppLayout = require('@/app/(app)/layout').default
+
+let mockReplace
+
+beforeEach(() => {
+  mockReplace = jest.fn()
+  useRouter.mockReturnValue({ replace: mockReplace })
+  usePathname.mockReturnValue('/dashboard')
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+function child() {
+  return React.createElement('div', null, 'page content')
+}
+
+// ---------------------------------------------------------------------------
+// Loading shell — live mode, auth not ready
+// ---------------------------------------------------------------------------
+describe('AppLayout — loading shell (live mode)', () => {
+  it('shows the loading shell when not ready and not authenticated', async () => {
+    useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: false })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(screen.getByText(/loading your budget space/i)).toBeTruthy()
+    expect(screen.queryByText('page content')).toBeNull()
+  })
+
+  it('shows the loading shell when ready but not yet authenticated', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: false })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(screen.getByText(/loading your budget space/i)).toBeTruthy()
+    expect(screen.queryByText('page content')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Redirect — live mode, unauthenticated after ready
+// ---------------------------------------------------------------------------
+describe('AppLayout — redirect to /login (live mode)', () => {
+  it('redirects to /login when ready and not authenticated', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: false })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(mockReplace).toHaveBeenCalledWith('/login')
+  })
+
+  it('does NOT redirect when authenticated', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
+    useDataMode.mockReturnValue({ isSampleMode: false })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Authenticated — renders children and nav
+// ---------------------------------------------------------------------------
+describe('AppLayout — authenticated (live mode)', () => {
+  it('renders children when authenticated', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
+    useDataMode.mockReturnValue({ isSampleMode: false })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(screen.getByText('page content')).toBeTruthy()
+  })
+
+  it('renders all 5 nav tab links', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
+    useDataMode.mockReturnValue({ isSampleMode: false })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    const navLinks = screen.getAllByRole('link')
+    const labels = navLinks.map((l) => l.textContent)
+    expect(labels.some((t) => /dashboard/i.test(t))).toBe(true)
+    expect(labels.some((t) => /planner/i.test(t))).toBe(true)
+    expect(labels.some((t) => /transactions/i.test(t))).toBe(true)
+    expect(labels.some((t) => /insights/i.test(t))).toBe(true)
+    expect(labels.some((t) => /account/i.test(t))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Demo / sample mode — guard skipped entirely
+// ---------------------------------------------------------------------------
+describe('AppLayout — demo / sample mode', () => {
+  it('renders children immediately without a session in sample mode', async () => {
+    useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: true })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(screen.getByText('page content')).toBeTruthy()
+    expect(screen.queryByText(/loading your budget space/i)).toBeNull()
+  })
+
+  it('does NOT redirect to /login in sample mode', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: true })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  it('marks the active tab correctly in sample mode', async () => {
+    usePathname.mockReturnValue('/dashboard')
+    useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: true })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    const activeLink = screen.getByRole('link', { name: /dashboard/i })
+    expect(activeLink.getAttribute('aria-current')).toBe('page')
+  })
+})

--- a/nextjs/__tests__/frontend/appLayout.unit.test.js
+++ b/nextjs/__tests__/frontend/appLayout.unit.test.js
@@ -1,10 +1,4 @@
 /** @jest-environment jsdom */
-// Source: src/app/(app)/layout.js
-//
-// Tests focus on the three guard behaviours:
-//   1. Show loading shell when not ready and not authenticated (live mode)
-//   2. Redirect to /login when ready but unauthenticated (live mode)
-//   3. Skip the guard entirely in demo/sample mode — render children immediately
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -16,7 +10,6 @@ jest.mock('@/components/providers', () => ({
   useDataMode: jest.fn(),
 }))
 
-// Stub next/link so it renders a plain <a> — keeps the DOM simple
 jest.mock('next/link', () => {
   const React = require('react')
   return function MockLink({ href, children, ...rest }) {
@@ -46,9 +39,6 @@ function child() {
   return React.createElement('div', null, 'page content')
 }
 
-// ---------------------------------------------------------------------------
-// Loading shell — live mode, auth not ready
-// ---------------------------------------------------------------------------
 describe('AppLayout — loading shell (live mode)', () => {
   it('shows the loading shell when not ready and not authenticated', async () => {
     useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
@@ -67,9 +57,6 @@ describe('AppLayout — loading shell (live mode)', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Redirect — live mode, unauthenticated after ready
-// ---------------------------------------------------------------------------
 describe('AppLayout — redirect to /login (live mode)', () => {
   it('redirects to /login when ready and not authenticated', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
@@ -86,9 +73,6 @@ describe('AppLayout — redirect to /login (live mode)', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Authenticated — renders children and nav
-// ---------------------------------------------------------------------------
 describe('AppLayout — authenticated (live mode)', () => {
   it('renders children when authenticated', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
@@ -111,9 +95,6 @@ describe('AppLayout — authenticated (live mode)', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// Demo / sample mode — guard skipped entirely
-// ---------------------------------------------------------------------------
 describe('AppLayout — demo / sample mode', () => {
   it('renders children immediately without a session in sample mode', async () => {
     useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })

--- a/nextjs/__tests__/frontend/appLayout.unit.test.js
+++ b/nextjs/__tests__/frontend/appLayout.unit.test.js
@@ -42,7 +42,7 @@ function child() {
 describe('AppLayout — loading shell (live mode)', () => {
   it('shows the loading shell when not ready and not authenticated', async () => {
     useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
-    useDataMode.mockReturnValue({ isSampleMode: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(screen.getByText(/loading your budget space/i)).toBeTruthy()
     expect(screen.queryByText('page content')).toBeNull()
@@ -50,7 +50,7 @@ describe('AppLayout — loading shell (live mode)', () => {
 
   it('shows the loading shell when ready but not yet authenticated', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
-    useDataMode.mockReturnValue({ isSampleMode: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(screen.getByText(/loading your budget space/i)).toBeTruthy()
     expect(screen.queryByText('page content')).toBeNull()
@@ -60,14 +60,21 @@ describe('AppLayout — loading shell (live mode)', () => {
 describe('AppLayout — redirect to /login (live mode)', () => {
   it('redirects to /login when ready and not authenticated', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
-    useDataMode.mockReturnValue({ isSampleMode: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(mockReplace).toHaveBeenCalledWith('/login')
   })
 
   it('does NOT redirect when authenticated', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
-    useDataMode.mockReturnValue({ isSampleMode: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: true })
+    await act(async () => { render(React.createElement(AppLayout, null, child())) })
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  it('does NOT redirect when data mode is not yet ready', async () => {
+    useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: false })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(mockReplace).not.toHaveBeenCalled()
   })
@@ -76,14 +83,14 @@ describe('AppLayout — redirect to /login (live mode)', () => {
 describe('AppLayout — authenticated (live mode)', () => {
   it('renders children when authenticated', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
-    useDataMode.mockReturnValue({ isSampleMode: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(screen.getByText('page content')).toBeTruthy()
   })
 
   it('renders all 5 nav tab links', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: true })
-    useDataMode.mockReturnValue({ isSampleMode: false })
+    useDataMode.mockReturnValue({ isSampleMode: false, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     const navLinks = screen.getAllByRole('link')
     const labels = navLinks.map((l) => l.textContent)
@@ -98,7 +105,7 @@ describe('AppLayout — authenticated (live mode)', () => {
 describe('AppLayout — demo / sample mode', () => {
   it('renders children immediately without a session in sample mode', async () => {
     useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
-    useDataMode.mockReturnValue({ isSampleMode: true })
+    useDataMode.mockReturnValue({ isSampleMode: true, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(screen.getByText('page content')).toBeTruthy()
     expect(screen.queryByText(/loading your budget space/i)).toBeNull()
@@ -106,7 +113,7 @@ describe('AppLayout — demo / sample mode', () => {
 
   it('does NOT redirect to /login in sample mode', async () => {
     useAuth.mockReturnValue({ isReady: true, isAuthenticated: false })
-    useDataMode.mockReturnValue({ isSampleMode: true })
+    useDataMode.mockReturnValue({ isSampleMode: true, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     expect(mockReplace).not.toHaveBeenCalled()
   })
@@ -114,7 +121,7 @@ describe('AppLayout — demo / sample mode', () => {
   it('marks the active tab correctly in sample mode', async () => {
     usePathname.mockReturnValue('/dashboard')
     useAuth.mockReturnValue({ isReady: false, isAuthenticated: false })
-    useDataMode.mockReturnValue({ isSampleMode: true })
+    useDataMode.mockReturnValue({ isSampleMode: true, isDataModeReady: true })
     await act(async () => { render(React.createElement(AppLayout, null, child())) })
     const activeLink = screen.getByRole('link', { name: /dashboard/i })
     expect(activeLink.getAttribute('aria-current')).toBe('page')

--- a/nextjs/__tests__/frontend/authLayout.unit.test.js
+++ b/nextjs/__tests__/frontend/authLayout.unit.test.js
@@ -7,12 +7,13 @@ jest.mock('next/navigation', () => ({
 
 jest.mock('@/components/providers', () => ({
   useAuth: jest.fn(),
+  useDataMode: jest.fn(),
 }))
 
 const React = require('react')
 const { render, screen, act } = require('@testing-library/react')
 const { useRouter, usePathname } = require('next/navigation')
-const { useAuth } = require('@/components/providers')
+const { useAuth, useDataMode } = require('@/components/providers')
 const AuthLayout = require('@/app/(auth)/layout').default
 
 const mockReplace = jest.fn()
@@ -29,6 +30,7 @@ beforeEach(() => {
   useRouter.mockReturnValue({ replace: mockReplace })
   usePathname.mockReturnValue('/login')
   setLocation('/login', '')
+  useDataMode.mockReturnValue({ setMode: jest.fn() })
 })
 
 afterEach(() => {

--- a/nextjs/__tests__/frontend/demoPage.unit.test.js
+++ b/nextjs/__tests__/frontend/demoPage.unit.test.js
@@ -1,41 +1,45 @@
 /** @jest-environment jsdom */
-// Source: src/app/demo/page.js
-//
-// DemoPage sets budgetbuddy.data-mode=sample in localStorage then redirects
-// to /dashboard — no UI is rendered.
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }))
 
+jest.mock('@/components/providers', () => ({
+  useDataMode: jest.fn(),
+}))
+
 const React = require('react')
 const { render, act } = require('@testing-library/react')
 const { useRouter } = require('next/navigation')
+const { useDataMode } = require('@/components/providers')
 const DemoPage = require('@/app/demo/page').default
 
 let mockReplace
+let mockSetMode
 
 beforeEach(() => {
   mockReplace = jest.fn()
+  mockSetMode = jest.fn()
   useRouter.mockReturnValue({ replace: mockReplace })
-  window.localStorage.clear()
+  useDataMode.mockReturnValue({ setMode: mockSetMode })
 })
 
 afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('DemoPage — localStorage', () => {
-  it('writes budgetbuddy.data-mode=sample to localStorage on mount', async () => {
+describe('DemoPage — setMode', () => {
+  it('calls setMode("sample") on mount', async () => {
     await act(async () => { render(React.createElement(DemoPage)) })
-    expect(window.localStorage.getItem('budgetbuddy.data-mode')).toBe('sample')
+    expect(mockSetMode).toHaveBeenCalledWith('sample')
   })
 
-  it('still redirects when localStorage.setItem throws', async () => {
-    const spy = jest.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => { throw new Error('quota') })
+  it('calls setMode before redirecting', async () => {
+    const callOrder = []
+    mockSetMode.mockImplementation(() => callOrder.push('setMode'))
+    mockReplace.mockImplementation(() => callOrder.push('replace'))
     await act(async () => { render(React.createElement(DemoPage)) })
-    expect(mockReplace).toHaveBeenCalledWith('/dashboard')
-    spy.mockRestore()
+    expect(callOrder).toEqual(['setMode', 'replace'])
   })
 })
 

--- a/nextjs/__tests__/frontend/demoPage.unit.test.js
+++ b/nextjs/__tests__/frontend/demoPage.unit.test.js
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+// Source: src/app/demo/page.js
+//
+// DemoPage sets budgetbuddy.data-mode=sample in localStorage then redirects
+// to /dashboard — no UI is rendered.
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+const React = require('react')
+const { render, act } = require('@testing-library/react')
+const { useRouter } = require('next/navigation')
+const DemoPage = require('@/app/demo/page').default
+
+let mockReplace
+
+beforeEach(() => {
+  mockReplace = jest.fn()
+  useRouter.mockReturnValue({ replace: mockReplace })
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('DemoPage — localStorage', () => {
+  it('writes budgetbuddy.data-mode=sample to localStorage on mount', async () => {
+    await act(async () => { render(React.createElement(DemoPage)) })
+    expect(window.localStorage.getItem('budgetbuddy.data-mode')).toBe('sample')
+  })
+
+  it('still redirects when localStorage.setItem throws', async () => {
+    const spy = jest.spyOn(window.localStorage.__proto__, 'setItem').mockImplementation(() => { throw new Error('quota') })
+    await act(async () => { render(React.createElement(DemoPage)) })
+    expect(mockReplace).toHaveBeenCalledWith('/dashboard')
+    spy.mockRestore()
+  })
+})
+
+describe('DemoPage — redirect', () => {
+  it('calls router.replace("/dashboard") on mount', async () => {
+    await act(async () => { render(React.createElement(DemoPage)) })
+    expect(mockReplace).toHaveBeenCalledTimes(1)
+    expect(mockReplace).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('renders nothing (returns null)', async () => {
+    const { container } = await act(async () => render(React.createElement(DemoPage)))
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/nextjs/__tests__/frontend/demoPage.unit.test.js
+++ b/nextjs/__tests__/frontend/demoPage.unit.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
   mockReplace = jest.fn()
   mockSetMode = jest.fn()
   useRouter.mockReturnValue({ replace: mockReplace })
-  useDataMode.mockReturnValue({ setMode: mockSetMode })
+  useDataMode.mockReturnValue({ isSampleMode: false, setMode: mockSetMode })
 })
 
 afterEach(() => {
@@ -33,20 +33,17 @@ describe('DemoPage — setMode', () => {
     await act(async () => { render(React.createElement(DemoPage)) })
     expect(mockSetMode).toHaveBeenCalledWith('sample')
   })
-
-  it('calls setMode before redirecting', async () => {
-    const callOrder = []
-    mockSetMode.mockImplementation(() => callOrder.push('setMode'))
-    mockReplace.mockImplementation(() => callOrder.push('replace'))
-    await act(async () => { render(React.createElement(DemoPage)) })
-    expect(callOrder).toEqual(['setMode', 'replace'])
-  })
 })
 
 describe('DemoPage — redirect', () => {
-  it('calls router.replace("/dashboard") on mount', async () => {
+  it('does NOT call router.replace until isSampleMode is true', async () => {
     await act(async () => { render(React.createElement(DemoPage)) })
-    expect(mockReplace).toHaveBeenCalledTimes(1)
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  it('calls router.replace("/dashboard") once isSampleMode becomes true', async () => {
+    useDataMode.mockReturnValue({ isSampleMode: true, setMode: mockSetMode })
+    await act(async () => { render(React.createElement(DemoPage)) })
     expect(mockReplace).toHaveBeenCalledWith('/dashboard')
   })
 

--- a/nextjs/__tests__/frontend/forgotPasswordForm.unit.test.js
+++ b/nextjs/__tests__/frontend/forgotPasswordForm.unit.test.js
@@ -35,6 +35,12 @@ describe('ForgotPasswordForm — idle state', () => {
     const link = screen.getByRole('link', { name: /log in/i })
     expect(link.getAttribute('href')).toBe('/login')
   })
+
+  it('renders an explore-demo link pointing to /demo', async () => {
+    await act(async () => { render(React.createElement(ForgotPasswordForm)) })
+    const link = screen.getByRole('link', { name: /explore a demo first/i })
+    expect(link.getAttribute('href')).toBe('/demo')
+  })
 })
 
 describe('ForgotPasswordForm — form submission', () => {

--- a/nextjs/__tests__/frontend/transactions.test.js
+++ b/nextjs/__tests__/frontend/transactions.test.js
@@ -214,7 +214,7 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     apiPost.mockResolvedValue({})
   })
 
-  it('opens add sheet with an empty category select (not Education) and a matching preview, not a letter fallback', async () => {
+  it('opens add sheet with the first category pre-selected and a matching preview', async () => {
     render(React.createElement(TransactionsView))
     await waitFor(() => {
       expect(screen.queryByText('Loading activity')).toBeNull()
@@ -224,12 +224,12 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     })
     const dialog = screen.getByRole('dialog')
     const select = within(dialog).getByRole('combobox')
-    expect(select.value).toBe('')
+    expect(select.value).toBe('Education')
     const previewAvatar = dialog.querySelector('.entry-avatar--large span')
-    expect(previewAvatar.textContent).toBe('\u{1F3F7}\uFE0F')
+    expect(previewAvatar.textContent).toBe('\u{1F4DA}')
   })
 
-  it('posts a new expense without category_id when the user does not select a category', async () => {
+  it('posts a new expense with the pre-selected first category', async () => {
     render(React.createElement(TransactionsView))
     await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
     act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
@@ -240,22 +240,20 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     await waitFor(() => { expect(apiPost).toHaveBeenCalled() })
     const expensePost = apiPost.mock.calls.find((c) => c[0] === '/api/expenses')
     expect(expensePost).toBeTruthy()
-    expect(expensePost[1].category_id).toBeUndefined()
+    expect(expensePost[1].category_id).toBe('c-edu')
   })
 
-  it('switches to income with an empty source select, not the first listed source (Business)', async () => {
+  it('switches to income with the first source pre-selected', async () => {
     render(React.createElement(TransactionsView))
     await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
     act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
     const dialog = screen.getByRole('dialog')
     act(() => { fireEvent.click(within(dialog).getByRole('button', { name: 'Income' })) })
     const select = within(dialog).getByRole('combobox')
-    expect(select.value).toBe('')
-    const previewAvatar = dialog.querySelector('.entry-avatar--large span')
-    expect(previewAvatar.textContent).toBe('\u{1F4CB}')
+    expect(select.value).toBe('Business')
   })
 
-  it('posts a new income row without source_id when the user does not select a source', async () => {
+  it('posts a new income row with the pre-selected first source', async () => {
     render(React.createElement(TransactionsView))
     await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
     act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
@@ -267,7 +265,7 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     await waitFor(() => { expect(apiPost).toHaveBeenCalled() })
     const incPost = apiPost.mock.calls.find((c) => c[0] === '/api/income')
     expect(incPost).toBeTruthy()
-    expect(incPost[1].source_id).toBeUndefined()
+    expect(incPost[1].source_id).toBe('i-bus')
   })
 
   it('sends category_id: null on update when editing an expense and clearing the category', async () => {

--- a/nextjs/e2e/demo.spec.js
+++ b/nextjs/e2e/demo.spec.js
@@ -1,0 +1,23 @@
+const { test, expect } = require('@playwright/test')
+
+test('demo flow: enter demo, see data, exit from account', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByRole('link', { name: /explore a demo first/i }).click()
+
+  // Lands on dashboard (not stuck on login)
+  await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 })
+  await expect(page.getByRole('heading', { name: 'Budgets' })).toBeVisible()
+  await expect(page.getByText('Recent activity')).toBeVisible()
+
+  // Exit demo via account page
+  await page.getByRole('link', { name: /account/i }).click()
+  await expect(page).toHaveURL(/\/account/, { timeout: 5_000 })
+  await page.getByRole('button', { name: /exit demo/i }).click()
+
+  await expect(page).toHaveURL(/\/login/, { timeout: 10_000 })
+
+  await page.evaluate(() => {
+    try { window.localStorage.removeItem('budgetbuddy.data-mode') } catch {}
+  })
+})
+

--- a/nextjs/src/app/(app)/account/page.js
+++ b/nextjs/src/app/(app)/account/page.js
@@ -99,7 +99,7 @@ export default function AccountPage() {
             </div>
           </div>
           <div className="demo-account-actions">
-            <Link className="button-primary demo-account-actions__cta" href="/signup" onClick={() => setMode('live')}>
+            <Link className="button-primary demo-account-actions__cta" href="/signup">
               Sign up free
             </Link>
             <Link className="button-secondary demo-account-actions__cta" href="/login" onClick={() => setMode('live')}>

--- a/nextjs/src/app/(app)/account/page.js
+++ b/nextjs/src/app/(app)/account/page.js
@@ -33,7 +33,7 @@ function getInitials(email) {
 export default function AccountPage() {
   const router = useRouter()
   const { user, logout } = useAuth()
-  const { mode, isSampleMode, setMode } = useDataMode()
+  const { isSampleMode, setMode } = useDataMode()
   const { theme, setTheme } = useTheme()
 
   const [isLoggingOut, setIsLoggingOut] = useState(false)
@@ -99,10 +99,10 @@ export default function AccountPage() {
             </div>
           </div>
           <div className="demo-account-actions">
-            <Link className="button-primary demo-account-actions__cta" href="/signup">
+            <Link className="button-primary demo-account-actions__cta" href="/signup" onClick={() => setMode('live')}>
               Sign up free
             </Link>
-            <Link className="button-secondary demo-account-actions__cta" href="/login">
+            <Link className="button-secondary demo-account-actions__cta" href="/login" onClick={() => setMode('live')}>
               Log in instead
             </Link>
           </div>
@@ -166,29 +166,7 @@ export default function AccountPage() {
               </div>
             </div>
 
-            <div className="settings-item">
-              <div aria-hidden="true" className="settings-item__icon">{isSampleMode ? '\u2726' : '\u25CF'}</div>
-              <div className="settings-item__copy">
-                <strong>Data mode</strong>
-                <span>{isSampleMode ? 'Sample data — exploring with demo content' : 'Live data — your real transactions'}</span>
-              </div>
-              <div className="segment-control segment-control--mini" role="group" aria-label="Data mode">
-                <button
-                  className={`segment-control__button${mode === 'live' ? ' segment-control__button--active' : ''}`}
-                  onClick={() => setMode('live')}
-                  type="button"
-                >
-                  Live
-                </button>
-                <button
-                  className={`segment-control__button${mode === 'sample' ? ' segment-control__button--active' : ''}`}
-                  onClick={() => setMode('sample')}
-                  type="button"
-                >
-                  Sample
-                </button>
-              </div>
-            </div>
+
           </div>
         </section>
 
@@ -199,7 +177,7 @@ export default function AccountPage() {
               <div aria-hidden="true" className="settings-item__icon">{'\u{1F4B3}'}</div>
               <div className="settings-item__copy">
                 <strong>Linked accounts</strong>
-                <span>{isSampleMode ? 'Connections stay on this device while you explore sample data.' : 'Linked accounts are available to view here.'}</span>
+                <span>Linked accounts are available to view here.</span>
               </div>
             </div>
 

--- a/nextjs/src/app/(app)/account/page.js
+++ b/nextjs/src/app/(app)/account/page.js
@@ -112,7 +112,7 @@ export default function AccountPage() {
           <span className="account-group__label">Actions</span>
           <button
             className="logout-action"
-            onClick={() => { setMode('live'); router.push('/login') }}
+            onClick={() => { setMode('live'); router.replace('/login') }}
             type="button"
           >
             <span aria-hidden="true" className="logout-action__icon">{'\u21A9'}</span>

--- a/nextjs/src/app/(app)/account/page.js
+++ b/nextjs/src/app/(app)/account/page.js
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth, useDataMode, useTheme } from '@/components/providers'
@@ -41,6 +42,87 @@ export default function AccountPage() {
     setIsLoggingOut(true)
     logout()
     router.replace('/login')
+  }
+
+  if (isSampleMode && !user?.email) {
+    return (
+      <section className="app-screen account-screen">
+        <article className="account-hero">
+          <div className="account-hero__avatar">BB</div>
+          <div className="account-hero__copy">
+            <span className="account-hero__eyebrow">Exploring sample data</span>
+            <h1>Demo mode</h1>
+            <p>You&apos;re browsing BudgetBuddy with sample data — none of this is real.</p>
+          </div>
+        </article>
+
+        <div className="account-layout">
+          <section className="account-group">
+            <span className="account-group__label">Preferences</span>
+            <div className="settings-panel">
+              <div className="settings-item">
+                <div aria-hidden="true" className="settings-item__icon">{'\u25D0'}</div>
+                <div className="settings-item__copy">
+                  <strong>Appearance</strong>
+                  <span>{theme === 'dark' ? 'Dark mode' : 'Light mode'}</span>
+                </div>
+                <div className="segment-control segment-control--mini" role="group" aria-label="Theme">
+                  <button
+                    className={`segment-control__button${theme === 'light' ? ' segment-control__button--active' : ''}`}
+                    onClick={() => setTheme('light')}
+                    type="button"
+                  >
+                    Light
+                  </button>
+                  <button
+                    className={`segment-control__button${theme === 'dark' ? ' segment-control__button--active' : ''}`}
+                    onClick={() => setTheme('dark')}
+                    type="button"
+                  >
+                    Dark
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <section className="account-group">
+          <span className="account-group__label">Ready to use BudgetBuddy for real?</span>
+          <div className="settings-panel">
+            <div className="settings-item settings-item--static">
+              <div aria-hidden="true" className="settings-item__icon">{'\u2726'}</div>
+              <div className="settings-item__copy">
+                <strong>Create a free account</strong>
+                <span>Track your real finances with your own data. Takes under a minute.</span>
+              </div>
+            </div>
+          </div>
+          <div className="demo-account-actions">
+            <Link className="button-primary demo-account-actions__cta" href="/signup">
+              Sign up free
+            </Link>
+            <Link className="button-secondary demo-account-actions__cta" href="/login">
+              Log in instead
+            </Link>
+          </div>
+        </section>
+
+        <section className="account-group">
+          <span className="account-group__label">Actions</span>
+          <button
+            className="logout-action"
+            onClick={() => { setMode('live'); router.push('/login') }}
+            type="button"
+          >
+            <span aria-hidden="true" className="logout-action__icon">{'\u21A9'}</span>
+            <span>Exit demo</span>
+          </button>
+        </section>
+
+        <div className="account-footer">BudgetBuddy v1.0</div>
+      </section>
+    )
   }
 
   return (

--- a/nextjs/src/app/(app)/layout.js
+++ b/nextjs/src/app/(app)/layout.js
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
-import { useAuth } from '@/components/providers'
+import { useAuth, useDataMode } from '@/components/providers'
 
 const NAV_ITEMS = [
   { href: '/dashboard', label: 'Dashboard', icon: 'dashboard' },
@@ -80,13 +80,15 @@ export default function AppLayout({ children }) {
   const pathname = usePathname()
   const router = useRouter()
   const { isReady, isAuthenticated } = useAuth()
+  const { isSampleMode } = useDataMode()
 
   useEffect(() => {
+    if (isSampleMode) return
     if (!isReady || isAuthenticated) return
     router.replace('/login')
-  }, [isAuthenticated, isReady, router])
+  }, [isAuthenticated, isReady, isSampleMode, router])
 
-  if (!isReady || !isAuthenticated) {
+  if (!isSampleMode && (!isReady || !isAuthenticated)) {
     return <AppLoadingShell />
   }
 

--- a/nextjs/src/app/(app)/layout.js
+++ b/nextjs/src/app/(app)/layout.js
@@ -80,13 +80,14 @@ export default function AppLayout({ children }) {
   const pathname = usePathname()
   const router = useRouter()
   const { isReady, isAuthenticated } = useAuth()
-  const { isSampleMode } = useDataMode()
+  const { isSampleMode, isDataModeReady } = useDataMode()
 
   useEffect(() => {
+    if (!isDataModeReady) return
     if (isSampleMode) return
     if (!isReady || isAuthenticated) return
     router.replace('/login')
-  }, [isAuthenticated, isReady, isSampleMode, router])
+  }, [isAuthenticated, isDataModeReady, isReady, isSampleMode, router])
 
   if (!isSampleMode && (!isReady || !isAuthenticated)) {
     return <AppLoadingShell />

--- a/nextjs/src/app/(auth)/layout.js
+++ b/nextjs/src/app/(auth)/layout.js
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
-import { useAuth } from '@/components/providers'
+import { useAuth, useDataMode } from '@/components/providers'
 
 function AuthRouteLoading() {
   return (
@@ -26,8 +26,13 @@ export default function AuthLayout({ children }) {
   const router = useRouter()
   const pathname = usePathname()
   const { isReady, isAuthenticated } = useAuth()
+  const { setMode } = useDataMode()
 
   const isRecovery = isRecoveryUrl(pathname)
+
+  useEffect(() => {
+    setMode('live')
+  }, [setMode])
 
   useEffect(() => {
     if (!isReady || !isAuthenticated) return

--- a/nextjs/src/app/demo/page.js
+++ b/nextjs/src/app/demo/page.js
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function DemoPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem('budgetbuddy.data-mode', 'sample')
+    } catch {}
+    router.replace('/dashboard')
+  }, [router])
+
+  return null
+}

--- a/nextjs/src/app/demo/page.js
+++ b/nextjs/src/app/demo/page.js
@@ -6,12 +6,15 @@ import { useDataMode } from '@/components/providers'
 
 export default function DemoPage() {
   const router = useRouter()
-  const { setMode } = useDataMode()
+  const { isSampleMode, setMode } = useDataMode()
 
   useEffect(() => {
     setMode('sample')
-    router.replace('/dashboard')
-  }, [router, setMode])
+  }, [setMode])
+
+  useEffect(() => {
+    if (isSampleMode) router.replace('/dashboard')
+  }, [isSampleMode, router])
 
   return null
 }

--- a/nextjs/src/app/demo/page.js
+++ b/nextjs/src/app/demo/page.js
@@ -2,16 +2,16 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useDataMode } from '@/components/providers'
 
 export default function DemoPage() {
   const router = useRouter()
+  const { setMode } = useDataMode()
 
   useEffect(() => {
-    try {
-      window.localStorage.setItem('budgetbuddy.data-mode', 'sample')
-    } catch {}
+    setMode('sample')
     router.replace('/dashboard')
-  }, [router])
+  }, [router, setMode])
 
   return null
 }

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -11632,3 +11632,23 @@ html[data-theme='dark'] .category-modal__row {
   line-height: 1.5;
 }
 
+/* ─── Demo account page actions ────────────────────────────────── */
+
+.demo-account-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0 1rem;
+  margin-top: 0.75rem;
+}
+
+.demo-account-actions__cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 1.5rem;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+

--- a/nextjs/src/components/auth-form.js
+++ b/nextjs/src/components/auth-form.js
@@ -207,6 +207,12 @@ export default function AuthForm({ mode, initialEmail = '', showSignupSuccess = 
           Can&apos;t remember your password?
         </Link>
       </p>
+
+      <p className="auth-card__switch">
+        <Link className="text-link" href="/demo">
+          Explore a demo first &rarr;
+        </Link>
+      </p>
     </section>
   )
 }

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -466,7 +466,7 @@ export default function DashboardView() {
     }
   }
 
-  if (!isReady || !session?.accessToken) {
+  if (!isSampleMode && (!isReady || !session?.accessToken)) {
     return null
   }
 
@@ -556,7 +556,7 @@ export default function DashboardView() {
       ]
     })()
     : buildRecentCashFlow(liveState.expenses, liveState.income, chartMonth, 3)
-  const firstName = getFirstName(session?.user?.email)
+  const firstName = isSampleMode ? 'Explorer' : getFirstName(session?.user?.email)
   const periodLabel = formatMonthPeriod(chartMonth)
   const previewCategories = [...categoryCards]
     .sort((left, right) => {

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -267,10 +267,6 @@ export default function DashboardView() {
     }
   }
 
-  if (!isSampleMode && (!isReady || !session?.accessToken)) {
-    return null
-  }
-
   const summary = isSampleMode ? demoBudgetSummary : liveState.summary
   const summaryAvailability = isSampleMode
     ? 'ready'
@@ -348,7 +344,7 @@ export default function DashboardView() {
     : null
   const chartSpendValue = trendPoints.length ? formatCurrency(trendPoints.at(-1) ?? 0) : '--'
 
-  if (!isReady || !session?.accessToken) {
+  if (!isSampleMode && (!isReady || !session?.accessToken)) {
     return null
   }
 

--- a/nextjs/src/components/forgot-password-form.js
+++ b/nextjs/src/components/forgot-password-form.js
@@ -129,6 +129,12 @@ export default function ForgotPasswordForm() {
           Back to log in
         </Link>
       </p>
+
+      <p className="auth-card__switch">
+        <Link className="text-link" href="/demo">
+          Explore a demo first &rarr;
+        </Link>
+      </p>
     </section>
   )
 }

--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -526,7 +526,7 @@ export default function InsightsView() {
     setIsMonthViewOpen(true)
   }
 
-  if (!isReady || !session?.accessToken) return null
+  if (!isSampleMode && (!isReady || !session?.accessToken)) return null
 
   const activeItems = getActiveBreakdownItems(snapshot, viewMode)
   const donutSegments = buildDonutSegments(activeItems)

--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -280,9 +280,6 @@ export default function InsightsView() {
       if (exportAbortRef.current === controller) exportAbortRef.current = null
     }
   }
-
-  if (!isSampleMode && (!isReady || !session?.accessToken)) return null
-
   const activeItems = useMemo(() => (
     getActiveBreakdownItems(snapshot, viewMode)
   ), [snapshot, viewMode])
@@ -360,7 +357,7 @@ export default function InsightsView() {
   const isViewingCurrentMonth = activeMonth === currentLiveMonth
   const todayDay = isViewingCurrentMonth ? new Date().getDate() : null
 
-  if (!isReady || !session?.accessToken) return null
+  if (!isSampleMode && (!isReady || !session?.accessToken)) return null
 
   const monthModal = isMonthViewOpen && portalRoot
     ? createPortal(

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -442,7 +442,7 @@ export default function PlannerView() {
     }
   }, [activeMonth, serverDraftSnapshot])
 
-  if (!isReady || !session?.accessToken) {
+  if (!isSampleMode && (!isReady || !session?.accessToken)) {
     return null
   }
 

--- a/nextjs/src/components/providers.js
+++ b/nextjs/src/components/providers.js
@@ -92,16 +92,14 @@ function AuthProvider({ children }) {
 }
 
 function DataModeProvider({ children }) {
-  const [mode, setModeState] = useState('live')
-
-  useEffect(() => {
-    setModeState(readStoredDataMode())
-  }, [])
+  const [mode, setModeState] = useState(() => {
+    if (typeof window === 'undefined') return 'live'
+    return readStoredDataMode()
+  })
 
   const setMode = (nextMode) => {
     const safeMode = nextMode === 'sample' ? 'sample' : 'live'
     setModeState(safeMode)
-
     try {
       window.localStorage.setItem(DATA_MODE_STORAGE_KEY, safeMode)
     } catch {}

--- a/nextjs/src/components/providers.js
+++ b/nextjs/src/components/providers.js
@@ -92,24 +92,28 @@ function AuthProvider({ children }) {
 }
 
 function DataModeProvider({ children }) {
-  const [mode, setModeState] = useState(() => {
-    if (typeof window === 'undefined') return 'live'
-    return readStoredDataMode()
-  })
+  const [mode, setModeState] = useState('live')
+  const [isDataModeReady, setIsDataModeReady] = useState(false)
 
-  const setMode = (nextMode) => {
+  useEffect(() => {
+    setModeState(readStoredDataMode())
+    setIsDataModeReady(true)
+  }, [])
+
+  const setMode = useCallback((nextMode) => {
     const safeMode = nextMode === 'sample' ? 'sample' : 'live'
     setModeState(safeMode)
     try {
       window.localStorage.setItem(DATA_MODE_STORAGE_KEY, safeMode)
     } catch {}
-  }
+  }, [])
 
   const value = useMemo(() => ({
     mode,
     isSampleMode: mode === 'sample',
+    isDataModeReady,
     setMode,
-  }), [mode])
+  }), [mode, isDataModeReady, setMode])
 
   return <DataModeContext.Provider value={value}>{children}</DataModeContext.Provider>
 }

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -179,6 +179,7 @@ function createEditDraft(entry) {
   return {
     ...base,
     counterparty: entry.raw?.notes || '',
+    note: entry.raw?.notes || '',
   }
 }
 

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -178,7 +178,7 @@ function createEditDraft(entry) {
   }
   return {
     ...base,
-    counterparty: '',
+    counterparty: entry.raw?.notes || '',
   }
 }
 
@@ -320,14 +320,13 @@ export default function TransactionsView() {
 
   useEffect(() => {
     if (!isEntrySheetOpen || editingEntry) return
-    if (entryDraft.category) return
     const firstCategory = entryDraft.kind === 'expense'
       ? expenseCategories[0]?.name
       : incomeCategories[0]?.name
     if (firstCategory) {
-     setEntryDraft((current) => ({ ...current, category: firstCategory }))
+      setEntryDraft((current) => ({ ...current, category: firstCategory }))
     }
-  }, [isEntrySheetOpen, editingEntry, entryDraft.category, entryDraft.kind, expenseCategories, incomeCategories])
+  }, [isEntrySheetOpen, editingEntry, entryDraft.kind, expenseCategories, incomeCategories])
 
   useEffect(() => {
     let hideTimeoutId

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -362,7 +362,7 @@ export default function TransactionsView() {
     apiGet('/api/income/categories', { accessToken: token }).then(setIncomeCategories).catch(() => {})
   }, [isReady, isSampleMode, session?.accessToken])
 
-  if (!isReady || !session?.accessToken) {
+  if (!isSampleMode && (!isReady || !session?.accessToken)) {
     return null
   }
 

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -178,8 +178,7 @@ function createEditDraft(entry) {
   }
   return {
     ...base,
-    counterparty: entry.raw?.notes || '',
-    note: entry.raw?.notes || '',
+    counterparty: '',
   }
 }
 
@@ -320,6 +319,17 @@ export default function TransactionsView() {
   }, [deleteConfirm, isEntrySheetOpen, selectedEntry])
 
   useEffect(() => {
+    if (!isEntrySheetOpen || editingEntry) return
+    if (entryDraft.category) return
+    const firstCategory = entryDraft.kind === 'expense'
+      ? expenseCategories[0]?.name
+      : incomeCategories[0]?.name
+    if (firstCategory) {
+     setEntryDraft((current) => ({ ...current, category: firstCategory }))
+    }
+  }, [isEntrySheetOpen, editingEntry, entryDraft.category, entryDraft.kind, expenseCategories, incomeCategories])
+
+  useEffect(() => {
     let hideTimeoutId
     let intervalId
 
@@ -397,8 +407,7 @@ export default function TransactionsView() {
   const entryCategories = entryDraft.kind === 'expense'
     ? (expenseCategories.length ? expenseCategories : ENTRY_CATEGORY_OPTIONS.expense.map((n) => ({ name: n, icon: null })))
     : (incomeCategories.length ? incomeCategories : ENTRY_CATEGORY_OPTIONS.income.map((n) => ({ name: n, icon: null })))
-  const hideFab = Boolean(selectedEntry) || isEntrySheetOpen
-
+  const hideFab = isSampleMode || Boolean(selectedEntry) || isEntrySheetOpen
   const updateDraft = (field, value) => {
     setEntryDraft((current) => ({
       ...current,
@@ -409,7 +418,11 @@ export default function TransactionsView() {
   const openEntrySheet = (entryToEdit = null) => {
     setEditingEntry(entryToEdit)
     setSelectedEntry(null)
-    setEntryDraft(entryToEdit ? createEditDraft(entryToEdit) : createEntryDraft())
+    const draft = entryToEdit ? createEditDraft(entryToEdit) : createEntryDraft()
+    if (!entryToEdit) {
+      draft.category = (draft.kind === 'expense' ? expenseCategories[0]?.name : incomeCategories[0]?.name) || ''
+    }
+    setEntryDraft(draft)
     setSaveError('')
     setIsEntrySheetOpen(true)
   }
@@ -421,6 +434,7 @@ export default function TransactionsView() {
   }
 
   const handleSaveEntry = async () => {
+    if (isSampleMode || !session?.accessToken) return
     if (isSaving) return
     setIsSaving(true)
     setSaveError('')
@@ -476,6 +490,7 @@ export default function TransactionsView() {
   }
 
   const handleDeleteEntry = async () => {
+    if (isSampleMode || !session?.accessToken) return
     if (isDeleting || !selectedEntry) return
     setIsDeleting(true)
     try {
@@ -782,8 +797,9 @@ export default function TransactionsView() {
                   <span>{categoryFieldLabel}</span>
                   <select
                     className="input-field"
+                    disabled={entryCategories.length === 0}
                     onChange={(event) => updateDraft('category', event.target.value)}
-                    value={entryDraft.category}
+                    value={entryCategories.length === 0 ? '' : entryDraft.category}
                   >
                     <option value="">
                       {entryDraft.kind === 'income' ? 'Select source' : 'Select category'}
@@ -792,8 +808,8 @@ export default function TransactionsView() {
                       <option key={option.name} value={option.name}>
                         {option.icon ? `${option.icon} ${option.name}` : option.name}
                       </option>
-                    ))}
-                  </select>
+                 ))}
+                </select>
                 </label>
 
                 <label className="entry-sheet__field">
@@ -836,7 +852,17 @@ export default function TransactionsView() {
                   </button>
                   <button
                     className="button-primary"
-                    disabled={isSaving || isSampleMode || !entryDraft.amount || !entryDraft.occurredOn}
+                    disabled={
+                      isSaving || 
+                      isSampleMode || 
+                      !entryDraft.amount || 
+                      !entryDraft.occurredOn || 
+                      (!editingEntry && (!entryDraft.category ||
+                        !entryCategories.some(
+                           (category) => category.name === entryDraft.category
+                        ))
+                      )
+                    }
                     type="submit"
                   >
                     {isSaving ? 'Saving...' : editingEntry ? 'Save changes' : 'Add transaction'}

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -320,12 +320,15 @@ export default function TransactionsView() {
 
   useEffect(() => {
     if (!isEntrySheetOpen || editingEntry) return
-    const firstCategory = entryDraft.kind === 'expense'
-      ? expenseCategories[0]?.name
-      : incomeCategories[0]?.name
-    if (firstCategory) {
-      setEntryDraft((current) => ({ ...current, category: firstCategory }))
-    }
+    const options = entryDraft.kind === 'expense' ? expenseCategories : incomeCategories
+    const firstCategory = options[0]?.name
+    if (!firstCategory) return
+    setEntryDraft((current) => {
+      const currentOptions = current.kind === 'expense' ? expenseCategories : incomeCategories
+      const isValid = currentOptions.some((o) => o.name === current.category)
+      if (current.category && isValid) return current
+      return { ...current, category: firstCategory }
+    })
   }, [isEntrySheetOpen, editingEntry, entryDraft.kind, expenseCategories, incomeCategories])
 
   useEffect(() => {
@@ -857,7 +860,7 @@ export default function TransactionsView() {
                       !entryDraft.amount || 
                       !entryDraft.occurredOn || 
                       (!editingEntry && (!entryDraft.category ||
-                        !entryCategories.some(
+                        !(entryDraft.kind === 'expense' ? expenseCategories : incomeCategories).some(
                            (category) => category.name === entryDraft.category
                         ))
                       )


### PR DESCRIPTION
## Description
This now separates the demo flow to be possible without logging into an existing account.

## Related User Story / Issue
Closes #75 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [x] GitHub Actions / CI tests passed
- [ ] Manual testing performed
- [ ] Not tested locally

### Test Notes
All Jest tests and E2E tests pass locally

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Screenshots
| Before | After |
| :--- | :--- |
| <img width="472" height="719" alt="image" src="https://github.com/user-attachments/assets/ba523fd2-630f-4e79-945f-09916bb9d2c5" /> | <img width="474" height="755" alt="image" src="https://github.com/user-attachments/assets/74943526-bc4c-4e4f-8432-58fe1f145d48" /> |
| No Demo Accounts Page | <img width="1199" height="882" alt="image" src="https://github.com/user-attachments/assets/71706324-3b9f-4ca4-a0ce-1958ee7e10cc" />|



## Notes for Reviewers
The demo flow is now completely in sign out state. Live mode is separated when logging in.

## Checklist
- [x] Linked to a user story or issue
- [x] Code builds / tests pass in CI
- [x] Ready for review