### PR TITLE
Improve dashboard and insights maintainability

### DIFF
--- a/nextjs/__tests__/expenses.test.js
+++ b/nextjs/__tests__/expenses.test.js
@@ -231,6 +231,19 @@ describe('GET /api/expenses', () => {
     })
   })
 
+  it('rejects an empty limit before querying', async () => {
+    await testApiHandler({
+      appHandler: expensesHandler,
+      url: 'http://localhost/api/expenses?limit=',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('Valid limit is required')
+        expect(db.query).not.toHaveBeenCalled()
+      }
+    })
+  })
+
   it.each([
     ['an empty month', 'http://localhost/api/expenses?month=', 'Valid month is required'],
     ['an invalid month', 'http://localhost/api/expenses?month=2026-13', 'Valid month is required'],

--- a/nextjs/__tests__/expenses.test.js
+++ b/nextjs/__tests__/expenses.test.js
@@ -230,6 +230,27 @@ describe('GET /api/expenses', () => {
       }
     })
   })
+
+  it.each([
+    ['an empty month', 'http://localhost/api/expenses?month=', 'Valid month is required'],
+    ['an invalid month', 'http://localhost/api/expenses?month=2026-13', 'Valid month is required'],
+    ['an empty from date', 'http://localhost/api/expenses?from=', 'Valid from date is required'],
+    ['an invalid from date', 'http://localhost/api/expenses?from=not-a-date', 'Valid from date is required'],
+    ['an empty to date', 'http://localhost/api/expenses?to=', 'Valid to date is required'],
+    ['an invalid to date', 'http://localhost/api/expenses?to=not-a-date', 'Valid to date is required'],
+    ['a from date after the to date', 'http://localhost/api/expenses?from=2026-03-15&to=2026-03-01', 'from date must be on or before to date'],
+  ])('rejects %s before querying', async (_label, url, expectedError) => {
+    await testApiHandler({
+      appHandler: expensesHandler,
+      url,
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe(expectedError)
+        expect(db.query).not.toHaveBeenCalled()
+      }
+    })
+  })
 })
 
 describe('POST /api/expenses/get', () => {

--- a/nextjs/__tests__/expenses.test.js
+++ b/nextjs/__tests__/expenses.test.js
@@ -168,6 +168,68 @@ describe('GET /api/expenses', () => {
       }
     })
   })
+
+  it('keeps the unfiltered list behavior when no query params are provided', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    await testApiHandler({
+      appHandler: expensesHandler,
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('WHERE e.user_id = $1'),
+          ['uid']
+        )
+        expect(db.query.mock.calls[0][0]).not.toContain('LIMIT')
+      }
+    })
+  })
+
+  it('can narrow expenses to a requested month', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    await testApiHandler({
+      appHandler: expensesHandler,
+      url: 'http://localhost/api/expenses?month=2026-03-01',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('WHERE e.user_id = $1 AND e.date >= $2 AND e.date < $3'),
+          ['uid', '2026-03-01', '2026-04-01']
+        )
+      }
+    })
+  })
+
+  it('can narrow expenses by date range and limit', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    await testApiHandler({
+      appHandler: expensesHandler,
+      url: 'http://localhost/api/expenses?from=2026-02-01&to=2026-02-28&limit=10',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('WHERE e.user_id = $1 AND e.date >= $2 AND e.date <= $3'),
+          ['uid', '2026-02-01', '2026-02-28']
+        )
+        expect(db.query.mock.calls[0][0]).toContain('LIMIT 10')
+      }
+    })
+  })
+
+  it('rejects ambiguous or invalid filters before querying', async () => {
+    await testApiHandler({
+      appHandler: expensesHandler,
+      url: 'http://localhost/api/expenses?month=2026-03-01&from=2026-03-01',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('Use either month or from/to, not both')
+        expect(db.query).not.toHaveBeenCalled()
+      }
+    })
+  })
 })
 
 describe('POST /api/expenses/get', () => {

--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -133,6 +133,11 @@ jest.mock('@/lib/financeUtils', () => ({
   formatShortDate: jest.fn((value) => value),
   getCurrentMonthStart: jest.fn((date = new Date()) => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-01`),
   isInMonth: jest.fn(),
+  shiftMonth: jest.fn((value, offset) => {
+    const date = new Date(`${value}T12:00:00Z`)
+    date.setUTCMonth(date.getUTCMonth() + offset)
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-01`
+  }),
 }))
 
 const React = require('react')
@@ -718,9 +723,11 @@ describe('DashboardView', () => {
       .mockResolvedValueOnce([
         { id: 'expense-1', date: '2026-03-11', category_name: 'Food', amount: '285.00' },
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         { id: 'income-1', date: '2026-03-02', source: 'Salary', amount: '2200.00' },
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         goals: [],
         summary: { active_count: 0, available_after_goal_contributions: null },
@@ -734,11 +741,36 @@ describe('DashboardView', () => {
     await renderDashboard()
 
     await waitFor(() => {
-      expect(apiGet).toHaveBeenCalledTimes(4)
+      expect(apiGet).toHaveBeenCalledTimes(6)
     })
     expect(apiGet).toHaveBeenNthCalledWith(
       1,
       `/api/budget/summary?month=${TEST_CURRENT_MONTH}`,
+      expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      2,
+      '/api/expenses?from=2026-01-01',
+      expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      3,
+      '/api/expenses?limit=6',
+      expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      4,
+      '/api/income?from=2026-01-01',
+      expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      5,
+      '/api/income?limit=6',
+      expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
+    )
+    expect(apiGet).toHaveBeenNthCalledWith(
+      6,
+      `/api/savings-goals?month=${TEST_CURRENT_MONTH}`,
       expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
     )
     expect(screen.getByText('Live')).toBeTruthy()
@@ -762,6 +794,8 @@ describe('DashboardView', () => {
       }))
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         goals: [
           {
@@ -783,7 +817,7 @@ describe('DashboardView', () => {
     await renderDashboard()
 
     await waitFor(() => {
-      expect(apiGet).toHaveBeenCalledTimes(4)
+      expect(apiGet).toHaveBeenCalledTimes(6)
     })
 
     expect(screen.getByText('Over budget')).toBeTruthy()
@@ -796,9 +830,11 @@ describe('DashboardView', () => {
       .mockResolvedValueOnce([
         { id: 'expense-1', date: '2026-03-11', category_name: 'Food', amount: '285.00' },
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         { id: 'income-1', date: '2026-03-02', source: 'Salary', amount: '2200.00' },
       ])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         goals: [],
         summary: { active_count: 0, available_after_goal_contributions: null },
@@ -826,6 +862,8 @@ describe('DashboardView', () => {
         category_statuses: [],
       }))
       .mockRejectedValueOnce(new Error('expenses unavailable'))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         goals: [],
@@ -867,6 +905,8 @@ describe('DashboardView', () => {
       .mockRejectedValueOnce(new ApiError('Expired session', 401))
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ goals: [], summary: { active_count: 0 } })
 
     await renderDashboard()
@@ -890,6 +930,8 @@ describe('DashboardView', () => {
       }))
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         goals: [],
         summary: { active_count: 0, available_after_goal_contributions: null },
@@ -903,6 +945,8 @@ describe('DashboardView', () => {
         threshold_exceeded: false,
         category_statuses: [],
       }))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
@@ -936,7 +980,7 @@ describe('DashboardView', () => {
       { accessToken: 'test-token' }
     )
     await waitFor(() => {
-      expect(apiGet).toHaveBeenCalledTimes(8)
+      expect(apiGet).toHaveBeenCalledTimes(12)
     })
     expect(screen.queryByText(/Current limit:/)).toBeNull()
   })

--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -781,6 +781,41 @@ describe('DashboardView', () => {
     expect(screen.getAllByText('Paycheck').length).toBeGreaterThan(0)
   })
 
+  it('passes merged live transaction rows to activity helpers in date-descending order', async () => {
+    const olderExpense = { id: 'expense-old', date: '2026-03-02', category_name: 'Food', amount: '12.00' }
+    const newerExpense = { id: 'expense-new', date: '2026-03-14', category_name: 'Travel', amount: '30.00' }
+    const olderIncome = { id: 'income-old', date: '2026-03-01', source: 'Bonus', amount: '200.00' }
+    const newerIncome = { id: 'income-new', date: '2026-03-18', source: 'Salary', amount: '2200.00' }
+
+    apiGet
+      .mockResolvedValueOnce(createLiveSummary({
+        monthly_limit: '1000.00',
+        total_budget: '1000.00',
+        total_expenses: '42.00',
+        total_income: '2400.00',
+        remaining_budget: '958.00',
+        threshold_exceeded: false,
+        category_statuses: [],
+      }))
+      .mockResolvedValueOnce([olderExpense])
+      .mockResolvedValueOnce([newerExpense])
+      .mockResolvedValueOnce([olderIncome])
+      .mockResolvedValueOnce([newerIncome])
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: { active_count: 0, available_after_goal_contributions: null },
+      })
+
+    await renderDashboard()
+
+    await waitFor(() => {
+      expect(financeUtils.buildActivityFeed).toHaveBeenCalledWith(
+        [newerExpense, olderExpense],
+        [newerIncome, olderIncome]
+      )
+    })
+  })
+
   it('shows a clear over-budget savings goal reason without remaining budget', async () => {
     apiGet
       .mockResolvedValueOnce(createLiveSummary({

--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -750,7 +750,7 @@ describe('DashboardView', () => {
     )
     expect(apiGet).toHaveBeenNthCalledWith(
       2,
-      '/api/expenses?from=2026-01-01',
+      '/api/expenses?from=2026-01-01&to=2026-03-31',
       expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
     )
     expect(apiGet).toHaveBeenNthCalledWith(
@@ -760,7 +760,7 @@ describe('DashboardView', () => {
     )
     expect(apiGet).toHaveBeenNthCalledWith(
       4,
-      '/api/income?from=2026-01-01',
+      '/api/income?from=2026-01-01&to=2026-03-31',
       expect.objectContaining({ accessToken: 'test-token', signal: expect.any(AbortSignal) })
     )
     expect(apiGet).toHaveBeenNthCalledWith(

--- a/nextjs/__tests__/income.test.js
+++ b/nextjs/__tests__/income.test.js
@@ -199,10 +199,13 @@ describe('GET /api/income', () => {
     })
   })
 
-  it('rejects invalid limits before querying', async () => {
+  it.each([
+    ['an empty limit', 'http://localhost/api/income?limit='],
+    ['a non-numeric limit', 'http://localhost/api/income?limit=ten'],
+  ])('rejects %s before querying', async (_label, url) => {
     await testApiHandler({
       appHandler: incomeHandler,
-      url: 'http://localhost/api/income?limit=ten',
+      url,
       async test({ fetch }) {
         const res = await fetch()
         expect(res.status).toBe(400)

--- a/nextjs/__tests__/income.test.js
+++ b/nextjs/__tests__/income.test.js
@@ -150,6 +150,68 @@ describe('GET /api/income', () => {
     })
   })
 
+  it('keeps the unfiltered list behavior when no query params are provided', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    await testApiHandler({
+      appHandler: incomeHandler,
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('WHERE i.user_id = $1'),
+          ['uid']
+        )
+        expect(db.query.mock.calls[0][0]).not.toContain('LIMIT')
+      }
+    })
+  })
+
+  it('can narrow income entries to a requested month', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    await testApiHandler({
+      appHandler: incomeHandler,
+      url: 'http://localhost/api/income?month=2026-03',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('WHERE i.user_id = $1 AND i.date >= $2 AND i.date < $3'),
+          ['uid', '2026-03-01', '2026-04-01']
+        )
+      }
+    })
+  })
+
+  it('can narrow income entries by date range and limit', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+    await testApiHandler({
+      appHandler: incomeHandler,
+      url: 'http://localhost/api/income?from=2026-02-01&to=2026-02-28&limit=5',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('WHERE i.user_id = $1 AND i.date >= $2 AND i.date <= $3'),
+          ['uid', '2026-02-01', '2026-02-28']
+        )
+        expect(db.query.mock.calls[0][0]).toContain('LIMIT 5')
+      }
+    })
+  })
+
+  it('rejects invalid limits before querying', async () => {
+    await testApiHandler({
+      appHandler: incomeHandler,
+      url: 'http://localhost/api/income?limit=ten',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('Valid limit is required')
+        expect(db.query).not.toHaveBeenCalled()
+      }
+    })
+  })
+
   it('returns 500 on db failure', async () => {
     db.query.mockRejectedValueOnce(new Error())
     await testApiHandler({

--- a/nextjs/__tests__/income.test.js
+++ b/nextjs/__tests__/income.test.js
@@ -215,6 +215,40 @@ describe('GET /api/income', () => {
     })
   })
 
+  it('rejects ambiguous month and range filters before querying', async () => {
+    await testApiHandler({
+      appHandler: incomeHandler,
+      url: 'http://localhost/api/income?month=2026-03-01&from=2026-03-01',
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('Use either month or from/to, not both')
+        expect(db.query).not.toHaveBeenCalled()
+      }
+    })
+  })
+
+  it.each([
+    ['an empty month', 'http://localhost/api/income?month=', 'Valid month is required'],
+    ['an invalid month', 'http://localhost/api/income?month=2026-13', 'Valid month is required'],
+    ['an empty from date', 'http://localhost/api/income?from=', 'Valid from date is required'],
+    ['an invalid from date', 'http://localhost/api/income?from=not-a-date', 'Valid from date is required'],
+    ['an empty to date', 'http://localhost/api/income?to=', 'Valid to date is required'],
+    ['an invalid to date', 'http://localhost/api/income?to=not-a-date', 'Valid to date is required'],
+    ['a from date after the to date', 'http://localhost/api/income?from=2026-03-15&to=2026-03-01', 'from date must be on or before to date'],
+  ])('rejects %s before querying', async (_label, url, expectedError) => {
+    await testApiHandler({
+      appHandler: incomeHandler,
+      url,
+      async test({ fetch }) {
+        const res = await fetch()
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe(expectedError)
+        expect(db.query).not.toHaveBeenCalled()
+      }
+    })
+  })
+
   it('returns 500 on db failure', async () => {
     db.query.mockRejectedValueOnce(new Error())
     await testApiHandler({

--- a/nextjs/__tests__/lib.dashboardModels.test.js
+++ b/nextjs/__tests__/lib.dashboardModels.test.js
@@ -1,4 +1,4 @@
-const { mergeRowsById, sortRowsByDateDesc } = require('@/lib/dashboardModels')
+const { buildDashboardLivePaths, mergeRowsById, sortRowsByDateDesc } = require('@/lib/dashboardModels')
 
 describe('mergeRowsById', () => {
   it('prefers later rows when duplicate ids are merged', () => {
@@ -27,5 +27,27 @@ describe('sortRowsByDateDesc', () => {
     const dated = { id: 'tx-3', created_at: '2026-03-08T10:00:00Z' }
 
     expect(sortRowsByDateDesc([first, dated, second])).toEqual([dated, first, second])
+  })
+})
+
+describe('buildDashboardLivePaths', () => {
+  it('bounds cash-flow transaction fetches to the displayed three-month window', () => {
+    expect(buildDashboardLivePaths('2026-03-01')).toEqual({
+      summary: '/api/budget/summary?month=2026-03-01',
+      cashFlowExpenses: '/api/expenses?from=2026-01-01&to=2026-03-31',
+      recentExpenses: '/api/expenses?limit=6',
+      cashFlowIncome: '/api/income?from=2026-01-01&to=2026-03-31',
+      recentIncome: '/api/income?limit=6',
+      savingsGoals: '/api/savings-goals?month=2026-03-01',
+    })
+  })
+
+  it('keeps recent activity limit-only while handling leap-year month ends', () => {
+    const paths = buildDashboardLivePaths('2024-02-01', { activityLimit: 4 })
+
+    expect(paths.cashFlowExpenses).toBe('/api/expenses?from=2023-12-01&to=2024-02-29')
+    expect(paths.cashFlowIncome).toBe('/api/income?from=2023-12-01&to=2024-02-29')
+    expect(paths.recentExpenses).toBe('/api/expenses?limit=4')
+    expect(paths.recentIncome).toBe('/api/income?limit=4')
   })
 })

--- a/nextjs/__tests__/lib.dashboardModels.test.js
+++ b/nextjs/__tests__/lib.dashboardModels.test.js
@@ -1,0 +1,11 @@
+const { mergeRowsById } = require('@/lib/dashboardModels')
+
+describe('mergeRowsById', () => {
+  it('prefers later rows when duplicate ids are merged', () => {
+    const older = { id: 'tx-1', amount: '10.00', label: 'older' }
+    const newer = { id: 'tx-1', amount: '12.50', label: 'newer' }
+    const unique = { id: 'tx-2', amount: '8.00', label: 'unique' }
+
+    expect(mergeRowsById([older], [unique, newer])).toEqual([newer, unique])
+  })
+})

--- a/nextjs/__tests__/lib.dashboardModels.test.js
+++ b/nextjs/__tests__/lib.dashboardModels.test.js
@@ -1,4 +1,4 @@
-const { mergeRowsById } = require('@/lib/dashboardModels')
+const { mergeRowsById, sortRowsByDateDesc } = require('@/lib/dashboardModels')
 
 describe('mergeRowsById', () => {
   it('prefers later rows when duplicate ids are merged', () => {
@@ -7,5 +7,25 @@ describe('mergeRowsById', () => {
     const unique = { id: 'tx-2', amount: '8.00', label: 'unique' }
 
     expect(mergeRowsById([older], [unique, newer])).toEqual([newer, unique])
+  })
+})
+
+describe('sortRowsByDateDesc', () => {
+  it('sorts rows by date descending without mutating the original list', () => {
+    const oldest = { id: 'tx-1', date: '2026-03-01' }
+    const newest = { id: 'tx-2', date: '2026-03-15' }
+    const middle = { id: 'tx-3', date: '2026-03-07' }
+    const rows = [oldest, newest, middle]
+
+    expect(sortRowsByDateDesc(rows)).toEqual([newest, middle, oldest])
+    expect(rows).toEqual([oldest, newest, middle])
+  })
+
+  it('keeps rows with equal or missing dates in their existing order', () => {
+    const first = { id: 'tx-1' }
+    const second = { id: 'tx-2' }
+    const dated = { id: 'tx-3', created_at: '2026-03-08T10:00:00Z' }
+
+    expect(sortRowsByDateDesc([first, dated, second])).toEqual([dated, first, second])
   })
 })

--- a/nextjs/src/app/api/expenses/route.js
+++ b/nextjs/src/app/api/expenses/route.js
@@ -2,18 +2,27 @@ import { NextResponse } from 'next/server'
 import db from '@/lib/db'
 import { authenticate } from '@/lib/auth'
 import { evaluateThresholdForMonth, isPositiveMoneyValue, normalizeDate } from '@/lib/budget'
+import { buildTransactionListQuery } from '@/lib/transactionQuery'
 
 export async function GET(request) {
   const { user, error } = await authenticate(request)
   if (error) return error
+  const query = buildTransactionListQuery(new URL(request.url).searchParams, {
+    dateColumn: 'e.date',
+    firstParameterIndex: 2,
+  })
+  if (query.error) return NextResponse.json({ error: query.error }, { status: 400 })
+
   try {
+    const whereClause = ['e.user_id = $1', ...query.clauses].join(' AND ')
     const { rows } = await db.query(
       `SELECT e.*, c.name AS category_name, c.icon AS category_icon
        FROM public.expenses e
        LEFT JOIN public.categories c ON e.category_id = c.id
-       WHERE e.user_id = $1
-       ORDER BY e.date DESC, e.created_at DESC`,
-      [user.id]
+       WHERE ${whereClause}
+       ORDER BY e.date DESC, e.created_at DESC
+       ${query.limitClause}`,
+      [user.id, ...query.values]
     )
     return NextResponse.json(rows.map(({ user_id, ...e }) => e))
   } catch {

--- a/nextjs/src/app/api/income/route.js
+++ b/nextjs/src/app/api/income/route.js
@@ -2,18 +2,27 @@ import { NextResponse } from 'next/server'
 import db from '@/lib/db'
 import { authenticate } from '@/lib/auth'
 import { isPositiveMoneyValue, normalizeDate } from '@/lib/budget'
+import { buildTransactionListQuery } from '@/lib/transactionQuery'
 
 export async function GET(request) {
   const { user, error } = await authenticate(request)
   if (error) return error
+  const query = buildTransactionListQuery(new URL(request.url).searchParams, {
+    dateColumn: 'i.date',
+    firstParameterIndex: 2,
+  })
+  if (query.error) return NextResponse.json({ error: query.error }, { status: 400 })
+
   try {
+    const whereClause = ['i.user_id = $1', ...query.clauses].join(' AND ')
     const { rows } = await db.query(
       `SELECT i.*, s.name AS source_name, s.icon AS source_icon
        FROM public.income i
        LEFT JOIN public.income_sources s ON i.source_id = s.id
-       WHERE i.user_id = $1
-       ORDER BY i.date DESC, i.created_at DESC`,
-      [user.id]
+       WHERE ${whereClause}
+       ORDER BY i.date DESC, i.created_at DESC
+       ${query.limitClause}`,
+      [user.id, ...query.values]
     )
     return NextResponse.json(rows.map(({ user_id, ...i }) => i))
   } catch {

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth, useDataMode, useDataChanged } from '@/components/providers'
 import { ApiError, apiGet, apiPost } from '@/lib/apiClient'
@@ -14,7 +14,7 @@ import {
   demoInsightsSnapshot,
   demoSavingsGoals,
 } from '@/lib/demoData'
-import { getCategoryPresentation, getEntryVisual, getInitialsLabel } from '@/lib/financeVisuals'
+import { getEntryVisual, getInitialsLabel } from '@/lib/financeVisuals'
 import {
   buildActivityFeed,
   buildDailySpendDetailsFromExpenses,
@@ -27,11 +27,23 @@ import {
   isInMonth,
 } from '@/lib/financeUtils'
 import {
-  buildBudgetPressureHighlight as buildSharedBudgetPressureHighlight,
-  buildCategoryBudgetHealth,
+  buildDashboardLivePaths,
+  buildDemoRecentCashFlow,
+  buildDerivedCategoryCards,
+  buildSampleCategoryCards,
+  getBudgetCtaLabel,
+  getBudgetHintText,
+  getBudgetHudModel,
+  getCategoryCards,
+  getFirstName,
+  getPreviewCategories,
+  getTopSavingsGoal,
+  hasCategoryBudgets,
+  hasOverallMonthlyLimit,
+  mergeRowsById,
+} from '@/lib/dashboardModels'
+import {
   buildFinancialHealth,
-  buildOverallBudgetHealth as buildSharedOverallBudgetHealth,
-  getMonthProgressState as getSharedMonthProgressState,
 } from '@/lib/budgetHealth'
 import {
   getSavingsGoalAvatar,
@@ -49,250 +61,21 @@ import MonthPacingChart from '@/components/ui/MonthPacingChart'
 import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const ACTIVITY_PREVIEW_LIMIT = 6
-const CATEGORY_PREVIEW_LIMIT = 5
+
+export {
+  buildDerivedCategoryCards,
+  getBudgetCtaLabel,
+  getBudgetHintText,
+  getBudgetHudModel,
+  getCategoryCards,
+  getMonthProgressState,
+  getBudgetPressureHighlight,
+} from '@/lib/dashboardModels'
 
 function getErrorMessage(error) {
   if (error instanceof ApiError) return error.message
   if (error instanceof Error && error.message) return error.message
   return 'Something went wrong while loading the live snapshot.'
-}
-
-function getFirstName(email) {
-  if (!email) return 'there'
-
-  const [name] = email.split('@')
-  const cleaned = name.replace(/[._-]+/g, ' ').trim()
-  return cleaned
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(' ')
-}
-
-export function hasOverallMonthlyLimit(summary) {
-  return Number(summary?.monthly_limit ?? 0) > 0
-}
-
-function hasBudgetedCategoryStatuses(categoryStatuses) {
-  return Array.isArray(categoryStatuses)
-    && categoryStatuses.some((item) => Number(item?.monthly_limit ?? 0) > 0)
-}
-
-export function hasCategoryBudgets(summary) {
-  return hasBudgetedCategoryStatuses(summary?.category_statuses)
-}
-
-export function getBudgetCtaLabel(summary) {
-  if (hasOverallMonthlyLimit(summary)) return 'Edit budget'
-  if (hasCategoryBudgets(summary)) return 'Set overall limit'
-  return 'Set budget'
-}
-
-export function getBudgetHintText(summary) {
-  if (hasOverallMonthlyLimit(summary)) {
-    return `Current limit: ${formatCurrency(summary?.monthly_limit)}. Changes take effect immediately.`
-  }
-
-  if (hasCategoryBudgets(summary)) {
-    return 'Category budgets are already set. Add an overall monthly limit here to control the monthly cap and overall-budget alerts.'
-  }
-
-  return 'Set an overall monthly limit here to control the monthly cap and overall-budget alerts.'
-}
-
-function getSafeMoneyNumber(value) {
-  const amount = Number(value)
-  return Number.isFinite(amount) ? amount : 0
-}
-
-export function getMonthProgressState(month, { observedDayCount = 0, referenceDate = new Date() } = {}) {
-  return getSharedMonthProgressState(month, { observedDayCount, referenceDate })
-}
-
-export function getBudgetHudModel(summary, { month, observedDayCount = 0, referenceDate = new Date(), availability = summary ? 'ready' : 'loading' } = {}) {
-  const overallHealth = buildSharedOverallBudgetHealth({
-    summary,
-    availability,
-    month,
-    observedDayCount,
-    referenceDate,
-  })
-  const financialHealth = buildFinancialHealth({ summary, availability })
-  const budget = overallHealth.totalBudget ?? 0
-  const spent = overallHealth.spent ?? 0
-  const income = getSafeMoneyNumber(summary?.total_income)
-  const net = financialHealth.netAmount ?? (income != null && overallHealth.spent != null
-    ? Number((income - overallHealth.spent).toFixed(2))
-    : 0)
-  const hasBudget = overallHealth.key !== 'no_budget' && overallHealth.key !== 'loading' && overallHealth.key !== 'unavailable'
-
-  const metrics = overallHealth.key === 'loading' || overallHealth.key === 'unavailable'
-    ? [
-      { label: 'Spent', value: '--', hint: 'Current month' },
-      {
-        label: 'Days left',
-        value: overallHealth.monthState.daysRemaining ? String(overallHealth.monthState.daysRemaining) : '--',
-        hint: 'Including today',
-      },
-      { label: 'Daily allowance', value: '--', hint: 'Left per day' },
-      { label: 'Net this month', value: '--', hint: 'Income minus spend' },
-    ]
-    : [
-      {
-        label: 'Spent',
-        value: formatCurrency(spent),
-        hint: hasBudget ? `${Math.round(overallHealth.progressPercentage)}% of budget used` : 'Current month',
-      },
-      {
-        label: 'Days left',
-        value: overallHealth.daysRemaining == null ? '--' : String(overallHealth.daysRemaining),
-        hint: 'Including today',
-      },
-      {
-        label: 'Daily allowance',
-        value: overallHealth.dailyAllowance == null ? '--' : formatCurrency(overallHealth.dailyAllowance),
-        hint: overallHealth.key === 'over_budget' ? 'Needs correction' : 'Left per day',
-      },
-      {
-        label: 'Net this month',
-        value: financialHealth.netAmount == null ? '--' : formatCurrency(financialHealth.netAmount),
-        hint: financialHealth.key === 'negative_cash_flow'
-          ? 'Expenses above income'
-          : 'Income minus spend',
-      },
-    ]
-
-  return {
-    ...overallHealth,
-    badge: overallHealth.label,
-    value: overallHealth.primaryValue,
-    progressWidth: `${overallHealth.progressPercentage}%`,
-    budget,
-    spent,
-    income: income ?? 0,
-    remaining: overallHealth.remaining,
-    net,
-    daysRemaining: overallHealth.daysRemaining,
-    hasBudget,
-    isOverBudget: overallHealth.key === 'over_budget',
-    isNearLimit: overallHealth.key === 'near_limit',
-    metrics,
-  }
-}
-
-function buildLiveCategoryCards(categoryStatuses = []) {
-  return categoryStatuses.map((item) => {
-    const presentation = getCategoryPresentation({
-      name: item.category_name,
-      icon: item.category_icon,
-      kind: 'expense',
-    })
-    const amount = Number(item.spent ?? 0)
-    const categoryHealth = buildCategoryBudgetHealth({
-      monthlyLimit: item.monthly_limit,
-      spent: item.spent,
-      actualsAvailable: true,
-    })
-
-    return {
-      id: item.category_id ?? item.category_name ?? `${item.category_name}-${amount}`,
-      name: presentation.label,
-      symbol: presentation.symbol,
-      color: presentation.color,
-      soft: presentation.soft,
-      progress: categoryHealth.progressPercentage,
-      amount,
-      monthlyLimit: Number(item.monthly_limit ?? 0) > 0 ? Number(item.monthly_limit) : null,
-      remainingAmount: categoryHealth.remainingAmount,
-      note: categoryHealth.remainingText,
-      statusLabel: categoryHealth.label,
-      statusTone: categoryHealth.tone,
-    }
-  })
-}
-
-export function buildDerivedCategoryCards(expenses = []) {
-  const grouped = new Map()
-
-  expenses.forEach((expense) => {
-    const amount = Number(expense.amount ?? 0)
-    const key = expense.category_id ?? expense.category_name ?? 'uncategorized'
-    const displayName = expense.category_name
-      && String(expense.category_name).trim() !== ''
-      ? String(expense.category_name).trim()
-      : ''
-    const existing = grouped.get(key)
-    const current = existing ?? {
-      category_name: displayName,
-      category_icon: expense.category_icon ?? null,
-      total_amount: 0,
-      count: 0,
-    }
-    if (!current.category_icon && expense.category_icon) {
-      current.category_icon = expense.category_icon
-    }
-
-    current.total_amount += amount
-    current.count += 1
-    grouped.set(key, current)
-  })
-
-  const breakdown = Array.from(grouped.entries())
-    .map(([key, item]) => ({
-      category_id: key,
-      category_name: item.category_name,
-      category_icon: item.category_icon ?? null,
-      total_amount: Number(item.total_amount.toFixed(2)),
-      count: item.count,
-    }))
-    .sort((left, right) => right.total_amount - left.total_amount)
-
-  const totalExpenses = breakdown.reduce((sum, item) => sum + Number(item.total_amount ?? 0), 0)
-
-  return breakdown.map((item) => {
-    const presentation = getCategoryPresentation({
-      name: item.category_name,
-      icon: item.category_icon,
-      kind: 'expense',
-    })
-    const amount = Number(item.total_amount ?? 0)
-    const share = totalExpenses > 0 ? (amount / totalExpenses) * 100 : 0
-
-    return {
-      id: item.category_id ?? item.category_name ?? `${item.category_name}-${amount}`,
-      name: presentation.label,
-      symbol: presentation.symbol,
-      color: presentation.color,
-      soft: presentation.soft,
-      progress: Math.min(share, 100),
-      amount,
-      monthlyLimit: null,
-      remainingAmount: null,
-      note: `${Math.round(share) || 0}% of spend`,
-    }
-  })
-}
-
-export function getCategoryCards(categoryStatuses, expenses = [], derivedCategoryCards = null) {
-  return hasBudgetedCategoryStatuses(categoryStatuses)
-    ? buildLiveCategoryCards(categoryStatuses)
-    : Array.isArray(derivedCategoryCards) ? derivedCategoryCards : buildDerivedCategoryCards(expenses)
-}
-
-export function getBudgetPressureHighlight(summary, expenses = [], derivedCategoryCards = null) {
-  const spendShareCards = Array.isArray(derivedCategoryCards)
-    ? derivedCategoryCards
-    : buildDerivedCategoryCards(expenses)
-
-  return buildSharedBudgetPressureHighlight({
-    categoryStatuses: summary?.category_statuses,
-    fallbackSpendCards: spendShareCards.map((card) => ({
-      name: card.name,
-      note: card.note,
-      progress: card.progress,
-      amount: card.amount,
-    })),
-  })
 }
 
 function LiveNotice({ message, onRetry }) {
@@ -346,20 +129,29 @@ export default function DashboardView() {
         message: '',
       }))
 
+      const paths = buildDashboardLivePaths(currentMonth)
       const results = await Promise.allSettled([
-        apiGet(`/api/budget/summary?month=${encodeURIComponent(currentMonth)}`, {
+        apiGet(paths.summary, {
           accessToken: session.accessToken,
           signal: controller.signal,
         }),
-        apiGet('/api/expenses', {
+        apiGet(paths.cashFlowExpenses, {
           accessToken: session.accessToken,
           signal: controller.signal,
         }),
-        apiGet('/api/income', {
+        apiGet(paths.recentExpenses, {
           accessToken: session.accessToken,
           signal: controller.signal,
         }),
-        apiGet('/api/savings-goals', {
+        apiGet(paths.cashFlowIncome, {
+          accessToken: session.accessToken,
+          signal: controller.signal,
+        }),
+        apiGet(paths.recentIncome, {
+          accessToken: session.accessToken,
+          signal: controller.signal,
+        }),
+        apiGet(paths.savingsGoals, {
           accessToken: session.accessToken,
           signal: controller.signal,
         }),
@@ -378,9 +170,11 @@ export default function DashboardView() {
       }
 
       const summaryResult = results[0]
-      const expensesResult = results[1]
-      const incomeResult = results[2]
-      const savingsGoalsResult = results[3]
+      const cashFlowExpensesResult = results[1]
+      const recentExpensesResult = results[2]
+      const cashFlowIncomeResult = results[3]
+      const recentIncomeResult = results[4]
+      const savingsGoalsResult = results[5]
       const failedCount = results.filter((result) => result.status === 'rejected').length
 
       setLiveState({
@@ -391,8 +185,14 @@ export default function DashboardView() {
             : 'Some live sections are missing for the moment, but the rest of the month is still visible.'
           : '',
         summary: summaryResult.status === 'fulfilled' ? summaryResult.value : null,
-        expenses: expensesResult.status === 'fulfilled' ? expensesResult.value : [],
-        income: incomeResult.status === 'fulfilled' ? incomeResult.value : [],
+        expenses: mergeRowsById(
+          cashFlowExpensesResult.status === 'fulfilled' ? cashFlowExpensesResult.value : [],
+          recentExpensesResult.status === 'fulfilled' ? recentExpensesResult.value : []
+        ),
+        income: mergeRowsById(
+          cashFlowIncomeResult.status === 'fulfilled' ? cashFlowIncomeResult.value : [],
+          recentIncomeResult.status === 'fulfilled' ? recentIncomeResult.value : []
+        ),
         savingsGoals: savingsGoalsResult.status === 'fulfilled' ? savingsGoalsResult.value : null,
       })
     }
@@ -466,10 +266,6 @@ export default function DashboardView() {
     }
   }
 
-  if (!isReady || !session?.accessToken) {
-    return null
-  }
-
   const summary = isSampleMode ? demoBudgetSummary : liveState.summary
   const summaryAvailability = isSampleMode
     ? 'ready'
@@ -478,101 +274,79 @@ export default function DashboardView() {
       : liveState.status === 'loading'
         ? 'loading'
         : 'unavailable'
-  const currentMonthExpenses = isSampleMode
-    ? []
-    : liveState.expenses.filter((expense) => isInMonth(expense.date || expense.created_at, currentMonth))
-  const categoryTransactionDetails = isSampleMode
-    ? (demoInsightsSnapshot?.dailySpend?.details ?? [])
-    : buildDailySpendDetailsFromExpenses(currentMonthExpenses)
-  const activity = isSampleMode
-    ? demoActivity
-    : buildActivityFeed(liveState.expenses, liveState.income)
-  const filteredActivity = activityFilter === 'all'
-    ? activity
-    : activity.filter((entry) => entry.kind === activityFilter)
-  const recentActivity = filteredActivity.slice(0, ACTIVITY_PREVIEW_LIMIT)
+  const currentMonthExpenses = useMemo(() => (
+    isSampleMode
+      ? []
+      : liveState.expenses.filter((expense) => isInMonth(expense.date || expense.created_at, currentMonth))
+  ), [currentMonth, isSampleMode, liveState.expenses])
+  const categoryTransactionDetails = useMemo(() => (
+    isSampleMode
+      ? (demoInsightsSnapshot?.dailySpend?.details ?? [])
+      : buildDailySpendDetailsFromExpenses(currentMonthExpenses)
+  ), [currentMonthExpenses, isSampleMode])
+  const activity = useMemo(() => (
+    isSampleMode
+      ? demoActivity
+      : buildActivityFeed(liveState.expenses, liveState.income)
+  ), [isSampleMode, liveState.expenses, liveState.income])
+  const filteredActivity = useMemo(() => (
+    activityFilter === 'all'
+      ? activity
+      : activity.filter((entry) => entry.kind === activityFilter)
+  ), [activity, activityFilter])
+  const recentActivity = useMemo(() => (
+    filteredActivity.slice(0, ACTIVITY_PREVIEW_LIMIT)
+  ), [filteredActivity])
   const chartMonth = isSampleMode ? DEMO_MONTH : summary?.month || currentMonth
-  const hasBudgetedStatuses = hasBudgetedCategoryStatuses(summary?.category_statuses)
-  const derivedCategoryCards = !isSampleMode && !hasBudgetedStatuses
-    ? buildDerivedCategoryCards(currentMonthExpenses)
-    : null
-  const categoryCards = isSampleMode
-    ? demoCategoryBudgets.map((item) => {
-      const presentation = getCategoryPresentation({ name: item.name, kind: 'expense' })
-      const categoryHealth = buildCategoryBudgetHealth({
-        monthlyLimit: item.budget,
-        spent: item.spent,
-        actualsAvailable: true,
-      })
-      return {
-        id: item.id,
-        name: presentation.label,
-        symbol: presentation.symbol,
-        color: presentation.color,
-        soft: presentation.soft,
-        progress: categoryHealth.progressPercentage,
-        amount: item.spent,
-        monthlyLimit: item.budget,
-        remainingAmount: categoryHealth.remainingAmount,
-        note: categoryHealth.remainingText,
-        statusLabel: categoryHealth.label,
-        statusTone: categoryHealth.tone,
-      }
-    })
-    : getCategoryCards(summary?.category_statuses, currentMonthExpenses, derivedCategoryCards)
+  const hasBudgetedStatuses = hasCategoryBudgets(summary)
+  const derivedCategoryCards = useMemo(() => (
+    !isSampleMode && !hasBudgetedStatuses
+      ? buildDerivedCategoryCards(currentMonthExpenses)
+      : null
+  ), [currentMonthExpenses, hasBudgetedStatuses, isSampleMode])
+  const categoryCards = useMemo(() => (
+    isSampleMode
+      ? buildSampleCategoryCards(demoCategoryBudgets)
+      : getCategoryCards(summary?.category_statuses, currentMonthExpenses, derivedCategoryCards)
+  ), [currentMonthExpenses, derivedCategoryCards, isSampleMode, summary?.category_statuses])
   const budgetCtaLabel = getBudgetCtaLabel(summary)
-  const trendPoints = isSampleMode
-    ? demoBudgetTrend
-    : buildMonthlySpendTrend(liveState.expenses, currentMonth)
-  const hudState = getBudgetHudModel(summary, {
+  const trendPoints = useMemo(() => (
+    isSampleMode
+      ? demoBudgetTrend
+      : buildMonthlySpendTrend(liveState.expenses, currentMonth)
+  ), [currentMonth, isSampleMode, liveState.expenses])
+  const hudState = useMemo(() => getBudgetHudModel(summary, {
     month: chartMonth,
     observedDayCount: trendPoints.length,
     availability: summaryAvailability,
-  })
-  const financialHealth = buildFinancialHealth({
+  }), [chartMonth, summary, summaryAvailability, trendPoints.length])
+  const financialHealth = useMemo(() => buildFinancialHealth({
     summary,
     availability: summaryAvailability,
-  })
+  }), [summary, summaryAvailability])
   const savingsGoals = isSampleMode ? demoSavingsGoals : liveState.savingsGoals
-  const topSavingsGoal = [...(savingsGoals?.goals ?? [])]
-    .filter((goal) => !goal.archived)
-    .sort((left, right) => {
-      const leftComplete = left.budget_context?.status === 'complete'
-      const rightComplete = right.budget_context?.status === 'complete'
-      if (leftComplete !== rightComplete) return leftComplete ? 1 : -1
-      const severity = { over_budget: 5, overdue: 5, tight: 4, no_budget: 3, ready: 2, complete: 1 }
-      const severityDifference = (severity[right.budget_context?.status] ?? 0) - (severity[left.budget_context?.status] ?? 0)
-      if (severityDifference) return severityDifference
-      return String(left.target_date).localeCompare(String(right.target_date))
-    })[0] ?? null
-  const recentCashFlow = isSampleMode
-    ? (() => {
-      const monthlyIncome = getSafeMoneyNumber(demoBudgetSummary?.total_income)
-      const monthlyExpenses = getSafeMoneyNumber(demoBudgetSummary?.total_expenses)
-      return [
-        { month: '2026-01-01', label: 'Jan', incomeAmount: monthlyIncome * 0.95, expenseAmount: monthlyExpenses * 0.88, netAmount: Number((monthlyIncome * 0.95 - monthlyExpenses * 0.88).toFixed(2)) },
-        { month: '2026-02-01', label: 'Feb', incomeAmount: monthlyIncome * 1.02, expenseAmount: monthlyExpenses * 1.05, netAmount: Number((monthlyIncome * 1.02 - monthlyExpenses * 1.05).toFixed(2)) },
-        { month: '2026-03-01', label: 'Mar', incomeAmount: monthlyIncome, expenseAmount: monthlyExpenses, netAmount: Number((monthlyIncome - monthlyExpenses).toFixed(2)) },
-      ]
-    })()
-    : buildRecentCashFlow(liveState.expenses, liveState.income, chartMonth, 3)
+  const topSavingsGoal = useMemo(() => (
+    getTopSavingsGoal(savingsGoals)
+  ), [savingsGoals])
+  const recentCashFlow = useMemo(() => (
+    isSampleMode
+      ? buildDemoRecentCashFlow(demoBudgetSummary)
+      : buildRecentCashFlow(liveState.expenses, liveState.income, chartMonth, 3)
+  ), [chartMonth, isSampleMode, liveState.expenses, liveState.income])
   const firstName = getFirstName(session?.user?.email)
   const periodLabel = formatMonthPeriod(chartMonth)
-  const previewCategories = [...categoryCards]
-    .sort((left, right) => {
-      const leftBudgeted = left.monthlyLimit != null && Number(left.monthlyLimit) > 0
-      const rightBudgeted = right.monthlyLimit != null && Number(right.monthlyLimit) > 0
-      if (leftBudgeted && rightBudgeted) {
-        return (Number(right.progress) || 0) - (Number(left.progress) || 0)
-      }
-      if (leftBudgeted !== rightBudgeted) return leftBudgeted ? -1 : 1
-      return (Number(right.amount) || 0) - (Number(left.amount) || 0)
-    })
-    .slice(0, CATEGORY_PREVIEW_LIMIT)
+  const previewCategories = useMemo(() => (
+    getPreviewCategories(categoryCards)
+  ), [categoryCards])
   const monthMarkerLabel = hudState.monthState?.monthLength
     ? `Today · Day ${hudState.monthState.activeDay}`
     : null
   const chartSpendValue = trendPoints.length ? formatCurrency(trendPoints.at(-1) ?? 0) : '--'
+
+  if (!isReady || !session?.accessToken) {
+    return null
+  }
+
   return (
     <>
     <section className="app-screen dashboard-screen">

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -41,6 +41,7 @@ import {
   hasCategoryBudgets,
   hasOverallMonthlyLimit,
   mergeRowsById,
+  sortRowsByDateDesc,
 } from '@/lib/dashboardModels'
 import {
   buildFinancialHealth,
@@ -185,14 +186,14 @@ export default function DashboardView() {
             : 'Some live sections are missing for the moment, but the rest of the month is still visible.'
           : '',
         summary: summaryResult.status === 'fulfilled' ? summaryResult.value : null,
-        expenses: mergeRowsById(
+        expenses: sortRowsByDateDesc(mergeRowsById(
           cashFlowExpensesResult.status === 'fulfilled' ? cashFlowExpensesResult.value : [],
           recentExpensesResult.status === 'fulfilled' ? recentExpensesResult.value : []
-        ),
-        income: mergeRowsById(
+        )),
+        income: sortRowsByDateDesc(mergeRowsById(
           cashFlowIncomeResult.status === 'fulfilled' ? cashFlowIncomeResult.value : [],
           recentIncomeResult.status === 'fulfilled' ? recentIncomeResult.value : []
-        ),
+        )),
         savingsGoals: savingsGoalsResult.status === 'fulfilled' ? savingsGoalsResult.value : null,
       })
     }

--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -16,381 +16,47 @@ import {
   getCurrentMonthStart,
   shiftMonth,
 } from '@/lib/financeUtils'
+import {
+  CASHFLOW_HEIGHT,
+  CASHFLOW_INSET_X,
+  CASHFLOW_WIDTH,
+  DONUT_CENTER,
+  DONUT_RADIUS,
+  DONUT_VIEWBOX,
+  buildCalendarGrid,
+  buildCashFlowGeometry,
+  buildCumulativeSeries,
+  buildDailyDetailMap,
+  buildDonutSegments,
+  buildRhythmBars,
+  clamp,
+  formatSignedCurrency,
+  getActiveBreakdownItems,
+  getBudgetUsageHeadline,
+  getCashFlowHighlights,
+  getDefaultSelectedDay,
+  getFilenameFromDisposition,
+  getMetricAccent,
+  getMetricDeltaContext,
+  getMetricDeltaValue,
+  getMetricValue,
+  getMonthLength,
+  getMonthShortLabel,
+  getMoverScaleMax,
+  pickTopExpensesFromDetails,
+} from '@/lib/insightsViewModels'
 import AllocationBar from '@/components/ui/AllocationBar'
 import CategoryProgressRow from '@/components/ui/CategoryProgressRow'
 import CategoryTransactionsModal from '@/components/ui/CategoryTransactionsModal'
 import PaceVsLastMonthChart from '@/components/ui/PaceVsLastMonthChart'
 import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
-const DONUT_VIEWBOX = 520
-const DONUT_CENTER = DONUT_VIEWBOX / 2
-const DONUT_RADIUS = 164
-const DONUT_STROKE_WIDTH = 42
-const DONUT_OUTER_RADIUS = DONUT_RADIUS + (DONUT_STROKE_WIDTH / 2)
-const DONUT_MARKER_RADIUS = DONUT_OUTER_RADIUS + 42
-
-const CASHFLOW_WIDTH = 560
-const CASHFLOW_HEIGHT = 344
-const CASHFLOW_INSET_X = 32
-const CASHFLOW_INSET_TOP = 24
-const CASHFLOW_INSET_BOTTOM = 52
-const CASHFLOW_BASELINE_RATIO = 0.53
-
-const CALENDAR_WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
-const RHYTHM_TICK_DAYS = [1, 7, 14, 21, 28]
+export { getActiveBreakdownItems } from '@/lib/insightsViewModels'
 
 function getErrorMessage(error) {
   if (error instanceof ApiError) return error.message
   if (error instanceof Error && error.message) return error.message
   return 'The live insights snapshot is not available right now.'
-}
-
-export function getActiveBreakdownItems(snapshot, viewMode = 'expenses') {
-  if (!snapshot) return []
-  return viewMode === 'income'
-    ? (snapshot.incomeBreakdown ?? [])
-    : (snapshot.expenseBreakdown ?? [])
-}
-
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max)
-}
-
-function formatSignedCurrency(value) {
-  const amount = Number(value ?? 0)
-  const sign = amount > 0 ? '+' : amount < 0 ? '-' : ''
-  return `${sign}${formatCurrency(Math.abs(amount))}`
-}
-
-function formatSignedPercentage(value) {
-  const amount = Number(value ?? 0)
-  const sign = amount > 0 ? '+' : amount < 0 ? '-' : ''
-  const absolute = Math.abs(amount)
-  const decimals = absolute >= 10 || Number.isInteger(absolute) ? 0 : 1
-  return `${sign}${absolute.toFixed(decimals)}%`
-}
-
-function getMetricValue(metric) {
-  if (metric.id === 'budget-left' && metric.currentAmount == null) return 'No budget'
-  return formatCurrency(metric.currentAmount ?? 0)
-}
-
-function getMetricDeltaValue(metric) {
-  if (metric.id === 'budget-left' && metric.currentAmount == null) return 'Set budget'
-  if (metric.deltaAmount == null) return 'No baseline'
-  if (metric.deltaAmount === 0) return 'Flat'
-  if ((metric.previousAmount ?? 0) > 0 && metric.deltaPercentage != null) {
-    return formatSignedPercentage(metric.deltaPercentage)
-  }
-  return formatSignedCurrency(metric.deltaAmount)
-}
-
-function getMetricDeltaContext(metric) {
-  if (metric.id === 'budget-left' && metric.currentAmount == null) return null
-  if (metric.deltaAmount == null) return null
-  return 'vs last month'
-}
-
-function getMetricAccent(metricId) {
-  if (metricId === 'income') return '\u2197'
-  if (metricId === 'expenses') return '\u2198'
-  if (metricId === 'net') return '\u223F'
-  if (metricId === 'budget-left') return '\u25CE'
-  return '\u2022'
-}
-
-function pickTopExpensesFromDetails(details = [], limit = 10) {
-  if (!Array.isArray(details) || !details.length) return []
-  return [...details]
-    .sort((left, right) => Number(right.amount ?? 0) - Number(left.amount ?? 0))
-    .slice(0, limit)
-}
-
-function getBudgetUsageHeadline(budgetHealth) {
-  if (!budgetHealth || budgetHealth.budgetAmount == null) return 'Budget not set'
-  return `${Math.round(budgetHealth.progressValue ?? 0)}% used`
-}
-
-function polarToCartesian(angle, radius) {
-  const radians = ((angle - 90) * Math.PI) / 180
-  return {
-    x: DONUT_CENTER + (radius * Math.cos(radians)),
-    y: DONUT_CENTER + (radius * Math.sin(radians)),
-  }
-}
-
-function describeArc(startAngle, endAngle) {
-  const start = polarToCartesian(endAngle, DONUT_RADIUS)
-  const end = polarToCartesian(startAngle, DONUT_RADIUS)
-  const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1'
-
-  return [
-    'M',
-    start.x.toFixed(3),
-    start.y.toFixed(3),
-    'A',
-    DONUT_RADIUS,
-    DONUT_RADIUS,
-    0,
-    largeArcFlag,
-    0,
-    end.x.toFixed(3),
-    end.y.toFixed(3),
-  ].join(' ')
-}
-
-function normalizeAngle(angle) {
-  const mod = angle % 360
-  return mod < 0 ? mod + 360 : mod
-}
-
-function getMinMarkerGap(count) {
-  if (count <= 1) return 360
-  if (count <= 2) return 110
-  if (count <= 3) return 70
-  if (count <= 4) return 52
-  if (count <= 5) return 38
-  return Math.max(Math.floor(360 / count) - 4, 28)
-}
-
-function resolveMarkerAngles(rawAngles, minGap) {
-  const count = rawAngles.length
-  if (count === 0) return []
-  if (count === 1) return [normalizeAngle(rawAngles[0])]
-
-  const sorted = rawAngles
-    .map((angle, index) => ({ angle: normalizeAngle(angle), index }))
-    .sort((left, right) => left.angle - right.angle)
-
-  for (let pass = 0; pass < 8; pass += 1) {
-    let moved = false
-
-    for (let i = 1; i < count; i += 1) {
-      const gap = sorted[i].angle - sorted[i - 1].angle
-      if (gap < minGap) {
-        sorted[i].angle = sorted[i - 1].angle + minGap
-        moved = true
-      }
-    }
-
-    const wrapGap = (360 + sorted[0].angle) - sorted[count - 1].angle
-    if (wrapGap < minGap) {
-      const shift = (minGap - wrapGap) / 2 + 0.01
-      sorted[count - 1].angle -= shift
-      sorted[0].angle += shift
-      moved = true
-    }
-
-    for (let i = count - 2; i >= 0; i -= 1) {
-      const gap = sorted[i + 1].angle - sorted[i].angle
-      if (gap < minGap) {
-        sorted[i].angle = sorted[i + 1].angle - minGap
-        moved = true
-      }
-    }
-
-    if (!moved) break
-  }
-
-  sorted.forEach((item) => {
-    item.angle = normalizeAngle(item.angle)
-    if (item.angle > 170 && item.angle < 190) {
-      item.angle = item.angle <= 180 ? 168 : 192
-    }
-  })
-
-  const result = new Array(count)
-  sorted.forEach(({ angle, index }) => { result[index] = normalizeAngle(angle) })
-  return result
-}
-
-function buildDonutSegments(items = []) {
-  const total = items.reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
-  if (!total) return []
-
-  const gapAngle = items.length > 1 ? 3.2 : 0
-  const midAngles = []
-  let currentAngle = 0
-
-  const rawSegments = items.map((item, index) => {
-    const sliceAngle = (Number(item.amount ?? 0) / total) * 360
-    const startAngle = currentAngle + (gapAngle / 2)
-    const endAngle = currentAngle + sliceAngle - (gapAngle / 2)
-    const safeEndAngle = endAngle <= startAngle
-      ? startAngle + Math.min(Math.max(sliceAngle, 1), 359.5)
-      : Math.min(endAngle, startAngle + 359.5)
-    const midAngle = startAngle + ((safeEndAngle - startAngle) / 2)
-    midAngles.push(midAngle)
-    currentAngle += sliceAngle
-
-    return {
-      ...item,
-      index,
-      path: describeArc(startAngle, safeEndAngle),
-      animationDelay: `${index * 90}ms`,
-    }
-  })
-
-  const resolvedAngles = resolveMarkerAngles(midAngles, getMinMarkerGap(items.length))
-
-  return rawSegments.map((segment, index) => {
-    const angle = resolvedAngles[index]
-    const anchor = polarToCartesian(angle, DONUT_MARKER_RADIUS)
-    return {
-      ...segment,
-      markerAngle: angle,
-      x: anchor.x,
-      y: anchor.y,
-      markerLeft: `${(anchor.x / DONUT_VIEWBOX) * 100}%`,
-      markerTop: `${(anchor.y / DONUT_VIEWBOX) * 100}%`,
-    }
-  })
-}
-
-function buildSmoothPath(points = []) {
-  if (!points.length) return ''
-  return points.reduce((path, point, index) => {
-    if (index === 0) return `M ${point.x.toFixed(2)} ${point.y.toFixed(2)}`
-    const previous = points[index - 1]
-    const controlX = (previous.x + point.x) / 2
-    return `${path} C ${controlX.toFixed(2)} ${previous.y.toFixed(2)}, ${controlX.toFixed(2)} ${point.y.toFixed(2)}, ${point.x.toFixed(2)} ${point.y.toFixed(2)}`
-  }, '')
-}
-
-function buildCashFlowGeometry(series = []) {
-  const plotBottom = CASHFLOW_HEIGHT - CASHFLOW_INSET_BOTTOM
-  const chartHeight = plotBottom - CASHFLOW_INSET_TOP
-  const baselineY = CASHFLOW_INSET_TOP + (chartHeight * CASHFLOW_BASELINE_RATIO)
-  const innerWidth = CASHFLOW_WIDTH - (CASHFLOW_INSET_X * 2)
-  const groupWidth = innerWidth / Math.max(series.length, 1)
-  const barWidth = clamp(groupWidth * 0.28, 18, 30)
-  const maxBarValue = Math.max(...series.flatMap((item) => [Number(item.incomeAmount ?? 0), Number(item.expenseAmount ?? 0)]), 1)
-  const maxNetValue = Math.max(...series.map((item) => Math.abs(Number(item.netAmount ?? 0))), 1)
-  const topBandHeight = baselineY - CASHFLOW_INSET_TOP - 8
-  const bottomBandHeight = plotBottom - baselineY - 10
-  const netBandHeight = Math.min(topBandHeight, bottomBandHeight) + 14
-  const guides = [
-    baselineY - (topBandHeight * 0.82),
-    baselineY - (topBandHeight * 0.48),
-    baselineY,
-    baselineY + (bottomBandHeight * 0.48),
-    baselineY + (bottomBandHeight * 0.82),
-  ]
-
-  const groups = series.map((item, index) => {
-    const centerX = CASHFLOW_INSET_X + (groupWidth * index) + (groupWidth / 2)
-    const incomeHeight = (Number(item.incomeAmount ?? 0) / maxBarValue) * topBandHeight
-    const expenseHeight = (Number(item.expenseAmount ?? 0) / maxBarValue) * bottomBandHeight
-    const visibleTop = clamp(Math.min(baselineY, baselineY - incomeHeight, baselineY - ((Number(item.netAmount ?? 0) / maxNetValue) * netBandHeight)) - 14, CASHFLOW_INSET_TOP + 4, plotBottom - 80)
-    const visibleBottom = clamp(Math.max(baselineY + expenseHeight, baselineY - ((Number(item.netAmount ?? 0) / maxNetValue) * netBandHeight)) + 14, CASHFLOW_INSET_TOP + 56, plotBottom + 6)
-    return {
-      ...item,
-      centerX,
-      barX: centerX - (barWidth / 2),
-      barWidth,
-      incomeY: baselineY - incomeHeight,
-      incomeHeight,
-      expenseY: baselineY,
-      expenseHeight,
-      netY: baselineY - ((Number(item.netAmount ?? 0) / maxNetValue) * netBandHeight),
-      labelY: CASHFLOW_HEIGHT - 10,
-      interactionX: centerX - (groupWidth / 2),
-      interactionY: visibleTop,
-      interactionWidth: groupWidth,
-      interactionHeight: visibleBottom - visibleTop,
-    }
-  })
-
-  return {
-    baselineY,
-    guides,
-    groups,
-    maxBarValue,
-    linePath: buildSmoothPath(groups.map((item) => ({ x: item.centerX, y: item.netY }))),
-  }
-}
-
-function buildCalendarGrid(series = [], month) {
-  if (!series.length || !month) return { weeks: [], weekdayLabels: CALENDAR_WEEKDAYS }
-  const monthDate = new Date(`${month}T12:00:00Z`)
-  if (Number.isNaN(monthDate.getTime())) return { weeks: [], weekdayLabels: CALENDAR_WEEKDAYS }
-
-  const firstDay = new Date(Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth(), 1, 12)).getUTCDay()
-  const maxAmount = Math.max(...series.map((item) => Number(item.amount ?? 0)), 1)
-  const cells = [
-    ...Array.from({ length: firstDay }, (_, index) => ({ key: `blank-start-${index}`, isBlank: true })),
-    ...series.map((item) => {
-      const ratio = Number(item.amount ?? 0) / maxAmount
-      let intensity = 0
-      if (item.amount > 0.001) intensity = 1
-      if (ratio >= 0.24) intensity = 2
-      if (ratio >= 0.5) intensity = 3
-      if (ratio >= 0.78) intensity = 4
-      return { ...item, intensity, isBlank: false }
-    }),
-  ]
-
-  while (cells.length % 7 !== 0) {
-    cells.push({ key: `blank-end-${cells.length}`, isBlank: true })
-  }
-
-  return {
-    weekdayLabels: CALENDAR_WEEKDAYS,
-    weeks: Array.from({ length: cells.length / 7 }, (_, index) => cells.slice(index * 7, (index + 1) * 7)),
-  }
-}
-
-function buildRhythmBars(series = []) {
-  const maxAmount = Math.max(...series.map((item) => Number(item.amount ?? 0)), 1)
-  const lastDay = series.at(-1)?.day ?? 0
-  const tickDays = [...new Set([...RHYTHM_TICK_DAYS, lastDay].filter((day) => day > 0 && day <= lastDay))]
-  return {
-    tickDays,
-    columns: series.map((item) => ({
-      ...item,
-      heightRatio: maxAmount > 0 ? Number(item.amount ?? 0) / maxAmount : 0,
-    })),
-  }
-}
-
-function buildDailyDetailMap(entries = []) {
-  return entries.reduce((map, entry) => {
-    if (!entry?.key) return map
-    if (!map[entry.key]) map[entry.key] = []
-    map[entry.key].push(entry)
-    return map
-  }, {})
-}
-
-function buildCumulativeSeries(series = []) {
-  let running = 0
-  return series.map((item) => {
-    running += Number(item?.amount ?? 0)
-    return {
-      day: Number(item?.day ?? 0),
-      amount: Number(running.toFixed(2)),
-    }
-  })
-}
-
-function getMonthLength(month) {
-  if (!month) return 31
-  const date = new Date(`${month}T12:00:00Z`)
-  if (Number.isNaN(date.getTime())) return 31
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0)).getUTCDate()
-}
-
-function getMonthShortLabel(month) {
-  if (!month) return 'Month'
-  const date = new Date(`${month}T12:00:00Z`)
-  if (Number.isNaN(date.getTime())) return 'Month'
-  return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })
-}
-
-function getDefaultSelectedDay(dailySpend) {
-  if (dailySpend?.peakDay?.key) return dailySpend.peakDay.key
-  const firstActiveDay = dailySpend?.series?.find((item) => Number(item.amount ?? 0) > 0)
-  return firstActiveDay?.key ?? null
 }
 
 function LiveNotice({ message, onRetry }) {
@@ -404,41 +70,6 @@ function LiveNotice({ message, onRetry }) {
       <button className="button-secondary page-retry" onClick={onRetry} type="button">Retry</button>
     </div>
   )
-}
-
-function getFilenameFromDisposition(value, fallback) {
-  if (!value) return fallback
-  const filenameStarMatch = value.match(/(?:^|;)\s*filename\*\s*=\s*([^;]+)/i)
-  const filenameMatch = value.match(/(?:^|;)\s*filename\s*=\s*("[^"]*"|[^;]+)/i)
-  const candidate = filenameStarMatch
-    ? decodeDispositionFilename(filenameStarMatch[1])
-    : decodeDispositionFilename(filenameMatch?.[1])
-  return sanitizeDownloadFilename(candidate, fallback)
-}
-
-function decodeDispositionFilename(value) {
-  if (!value) return ''
-  const text = value.trim().replace(/^"|"$/g, '')
-  const encodedMatch = text.match(/^([^']*)'[^']*'(.*)$/)
-  if (!encodedMatch) return text
-
-  try {
-    return decodeURIComponent(encodedMatch[2])
-  } catch {
-    return ''
-  }
-}
-
-function sanitizeDownloadFilename(value, fallback) {
-  const cleaned = String(value || '')
-    .replace(/[\u0000-\u001f\u007f]+/g, '')
-    .replace(/[\\/]+/g, '-')
-    .replace(/[:*?"<>|]+/g, '_')
-    .trim()
-    .slice(0, 120)
-
-  if (!cleaned || cleaned === '.' || cleaned === '..' || !/[A-Za-z0-9]/.test(cleaned)) return fallback
-  return cleaned
 }
 
 export default function InsightsView() {
@@ -650,10 +281,12 @@ export default function InsightsView() {
     }
   }
 
-  if (!isReady || !session?.accessToken) return null
-
-  const activeItems = getActiveBreakdownItems(snapshot, viewMode)
-  const donutSegments = buildDonutSegments(activeItems)
+  const activeItems = useMemo(() => (
+    getActiveBreakdownItems(snapshot, viewMode)
+  ), [snapshot, viewMode])
+  const donutSegments = useMemo(() => (
+    buildDonutSegments(activeItems)
+  ), [activeItems])
   const comparisonMetrics = snapshot?.comparisonMetrics ?? []
   const budgetHealth = snapshot?.budgetHealth ?? { tone: 'neutral', statusLabel: 'No budget', budgetAmount: null, spentAmount: 0, remainingAmount: null, progressValue: 0, pressureCategories: [] }
   const savingsGoals = isSampleMode ? demoSavingsGoals : snapshot?.savingsGoals
@@ -666,48 +299,66 @@ export default function InsightsView() {
   const previousDisabled = isSampleMode || !earliestMonth || activeMonth <= earliestMonth
   const nextDisabled = isSampleMode || activeMonth >= currentLiveMonth
   const activeMonthLabel = formatMonthLabel(activeMonth)
-  const activeTotal = activeItems.reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
-  const cashFlowGeometry = buildCashFlowGeometry(cashFlowSeries)
-  const activeCashGroup = activeCashMonth ? cashFlowGeometry.groups.find((item) => item.month === activeCashMonth) ?? null : null
+  const activeTotal = useMemo(() => (
+    activeItems.reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
+  ), [activeItems])
+  const cashFlowGeometry = useMemo(() => (
+    buildCashFlowGeometry(cashFlowSeries)
+  ), [cashFlowSeries])
+  const activeCashGroup = useMemo(() => (
+    activeCashMonth
+      ? cashFlowGeometry.groups.find((item) => item.month === activeCashMonth) ?? null
+      : null
+  ), [activeCashMonth, cashFlowGeometry.groups])
   const focusCashGroup = activeCashGroup ?? cashFlowGeometry.groups.at(-1) ?? null
   const dailyPeak = dailySpend.peakDay
-  const calendarGrid = buildCalendarGrid(dailySpend.series, activeMonth)
-  const rhythmBars = buildRhythmBars(dailySpend.series)
-  const dailyDetailMap = buildDailyDetailMap(dailySpend.details ?? [])
-  const selectedDayEntries = selectedDayKey ? (dailyDetailMap[selectedDayKey] ?? []) : []
+  const calendarGrid = useMemo(() => (
+    buildCalendarGrid(dailySpend.series, activeMonth)
+  ), [activeMonth, dailySpend.series])
+  const rhythmBars = useMemo(() => (
+    buildRhythmBars(dailySpend.series)
+  ), [dailySpend.series])
+  const dailyDetailMap = useMemo(() => (
+    buildDailyDetailMap(dailySpend.details ?? [])
+  ), [dailySpend.details])
+  const selectedDayEntries = useMemo(() => (
+    selectedDayKey ? (dailyDetailMap[selectedDayKey] ?? []) : []
+  ), [dailyDetailMap, selectedDayKey])
   const selectedDayLabel = selectedDayKey ? formatLongDate(selectedDayKey) : activeMonthLabel
-  const activeRhythmEntry = activeRhythmDay ? dailySpend.series.find((item) => item.key === activeRhythmDay) ?? null : null
+  const activeRhythmEntry = useMemo(() => (
+    activeRhythmDay ? dailySpend.series.find((item) => item.key === activeRhythmDay) ?? null : null
+  ), [activeRhythmDay, dailySpend.series])
   const centerLabelLines = viewMode === 'expenses' ? ['Spent', 'this month'] : ['Income', 'this month']
   const detailSectionLabel = viewMode === 'income' ? 'Source detail' : 'Category detail'
   const trailingCategoryId = activeItems.length > 2 && activeItems.length % 2 === 1 ? activeItems.at(-1)?.id : null
-  const moverScaleMax = Math.max(
-    ...categoryMovers.flatMap((entry) => [Number(entry.amount ?? 0), Number(entry.previousAmount ?? 0)]),
-    1
-  )
-  const positiveCashMonths = cashFlowSeries.filter((item) => Number(item.netAmount ?? 0) >= 0).length
-  const strongestCashMonth = cashFlowSeries.reduce((best, item) => (
-    !best || Number(item.netAmount ?? 0) > Number(best.netAmount ?? 0) ? item : best
-  ), null)
-  const highestExpenseMonth = cashFlowSeries.reduce((best, item) => (
-    !best || Number(item.expenseAmount ?? 0) > Number(best.expenseAmount ?? 0) ? item : best
-  ), null)
-  const focusSavingsRate = focusCashGroup && Number(focusCashGroup.incomeAmount ?? 0) > 0
-    ? (Number(focusCashGroup.netAmount ?? 0) / Number(focusCashGroup.incomeAmount ?? 0)) * 100
-    : null
-  const cashFlowFocusTone = focusCashGroup && Number(focusCashGroup.netAmount ?? 0) < 0 ? 'negative' : 'positive'
-  const cashFlowHealthLabel = cashFlowSeries.length && positiveCashMonths === cashFlowSeries.length
-    ? 'Every month positive'
-    : `${positiveCashMonths}/${cashFlowSeries.length} positive months`
-  const cashFlowHealthCopy = focusCashGroup
-    ? `${focusCashGroup.label} kept ${formatPercentage(focusSavingsRate ?? 0)} of income after expenses.`
-    : 'Cash-flow highlights appear after a few months of activity.'
+  const moverScaleMax = useMemo(() => (
+    getMoverScaleMax(categoryMovers)
+  ), [categoryMovers])
+  const {
+    cashFlowFocusTone,
+    cashFlowHealthCopy,
+    cashFlowHealthLabel,
+    focusSavingsRate,
+    highestExpenseMonth,
+    positiveCashMonths,
+    strongestCashMonth,
+  } = useMemo(() => (
+    getCashFlowHighlights(cashFlowSeries, focusCashGroup)
+  ), [cashFlowSeries, focusCashGroup])
 
-  const paceCurrentSeries = buildCumulativeSeries(dailySpend.series)
-  const pacePreviousSeries = buildCumulativeSeries(previousDailySpend.series || [])
+  const paceCurrentSeries = useMemo(() => (
+    buildCumulativeSeries(dailySpend.series)
+  ), [dailySpend.series])
+  const pacePreviousSeries = useMemo(() => (
+    buildCumulativeSeries(previousDailySpend.series || [])
+  ), [previousDailySpend.series])
   const previousMonthShortLabel = getMonthShortLabel(snapshot?.previousMonth || previousMonth)
   const currentMonthShortLabel = getMonthShortLabel(activeMonth)
+  const monthLength = useMemo(() => getMonthLength(activeMonth), [activeMonth])
   const isViewingCurrentMonth = activeMonth === currentLiveMonth
   const todayDay = isViewingCurrentMonth ? new Date().getDate() : null
+
+  if (!isReady || !session?.accessToken) return null
 
   const monthModal = isMonthViewOpen && portalRoot
     ? createPortal(
@@ -1122,7 +773,7 @@ export default function InsightsView() {
                 ariaLabel="Budget health progress"
                 ariaValueText={`${Math.round(budgetHealth.progressValue ?? 0)}% used`}
                 isOverBudget={(budgetHealth.remainingAmount ?? 0) < 0}
-                monthLength={getMonthLength(activeMonth)}
+                monthLength={monthLength}
                 monthMarkerLabel={isViewingCurrentMonth ? `Today · Day ${todayDay}` : null}
                 progressPercentage={budgetHealth.progressValue ?? 0}
                 showMarker={Boolean(budgetHealth.budgetAmount) && isViewingCurrentMonth}
@@ -1367,7 +1018,7 @@ export default function InsightsView() {
               previousMonthSeries={pacePreviousSeries}
               currentMonthLabel={currentMonthShortLabel}
               previousMonthLabel={previousMonthShortLabel}
-              monthLength={getMonthLength(activeMonth)}
+              monthLength={monthLength}
             />
           </div>
         </section>

--- a/nextjs/src/lib/dashboardModels.js
+++ b/nextjs/src/lib/dashboardModels.js
@@ -1,0 +1,343 @@
+import { getCategoryPresentation } from './financeVisuals'
+import {
+  formatCurrency,
+  shiftMonth,
+} from './financeUtils'
+import {
+  buildBudgetPressureHighlight as buildSharedBudgetPressureHighlight,
+  buildCategoryBudgetHealth,
+  buildFinancialHealth,
+  buildOverallBudgetHealth as buildSharedOverallBudgetHealth,
+  getMonthProgressState as getSharedMonthProgressState,
+} from './budgetHealth'
+
+const DEFAULT_CATEGORY_PREVIEW_LIMIT = 5
+const DEFAULT_RECENT_ACTIVITY_LIMIT = 6
+
+function hasBudgetedCategoryStatuses(categoryStatuses) {
+  return Array.isArray(categoryStatuses)
+    && categoryStatuses.some((item) => Number(item?.monthly_limit ?? 0) > 0)
+}
+
+function getSafeMoneyNumber(value) {
+  const amount = Number(value)
+  return Number.isFinite(amount) ? amount : 0
+}
+
+export function getFirstName(email) {
+  if (!email) return 'there'
+
+  const [name] = email.split('@')
+  const cleaned = name.replace(/[._-]+/g, ' ').trim()
+  return cleaned
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function hasOverallMonthlyLimit(summary) {
+  return Number(summary?.monthly_limit ?? 0) > 0
+}
+
+export function hasCategoryBudgets(summary) {
+  return hasBudgetedCategoryStatuses(summary?.category_statuses)
+}
+
+export function getBudgetCtaLabel(summary) {
+  if (hasOverallMonthlyLimit(summary)) return 'Edit budget'
+  if (hasCategoryBudgets(summary)) return 'Set overall limit'
+  return 'Set budget'
+}
+
+export function getBudgetHintText(summary) {
+  if (hasOverallMonthlyLimit(summary)) {
+    return `Current limit: ${formatCurrency(summary?.monthly_limit)}. Changes take effect immediately.`
+  }
+
+  if (hasCategoryBudgets(summary)) {
+    return 'Category budgets are already set. Add an overall monthly limit here to control the monthly cap and overall-budget alerts.'
+  }
+
+  return 'Set an overall monthly limit here to control the monthly cap and overall-budget alerts.'
+}
+
+export function getMonthProgressState(month, { observedDayCount = 0, referenceDate = new Date() } = {}) {
+  return getSharedMonthProgressState(month, { observedDayCount, referenceDate })
+}
+
+export function getBudgetHudModel(summary, { month, observedDayCount = 0, referenceDate = new Date(), availability = summary ? 'ready' : 'loading' } = {}) {
+  const overallHealth = buildSharedOverallBudgetHealth({
+    summary,
+    availability,
+    month,
+    observedDayCount,
+    referenceDate,
+  })
+  const financialHealth = buildFinancialHealth({ summary, availability })
+  const budget = overallHealth.totalBudget ?? 0
+  const spent = overallHealth.spent ?? 0
+  const income = getSafeMoneyNumber(summary?.total_income)
+  const net = financialHealth.netAmount ?? (income != null && overallHealth.spent != null
+    ? Number((income - overallHealth.spent).toFixed(2))
+    : 0)
+  const hasBudget = overallHealth.key !== 'no_budget' && overallHealth.key !== 'loading' && overallHealth.key !== 'unavailable'
+
+  const metrics = overallHealth.key === 'loading' || overallHealth.key === 'unavailable'
+    ? [
+      { label: 'Spent', value: '--', hint: 'Current month' },
+      {
+        label: 'Days left',
+        value: overallHealth.monthState.daysRemaining ? String(overallHealth.monthState.daysRemaining) : '--',
+        hint: 'Including today',
+      },
+      { label: 'Daily allowance', value: '--', hint: 'Left per day' },
+      { label: 'Net this month', value: '--', hint: 'Income minus spend' },
+    ]
+    : [
+      {
+        label: 'Spent',
+        value: formatCurrency(spent),
+        hint: hasBudget ? `${Math.round(overallHealth.progressPercentage)}% of budget used` : 'Current month',
+      },
+      {
+        label: 'Days left',
+        value: overallHealth.daysRemaining == null ? '--' : String(overallHealth.daysRemaining),
+        hint: 'Including today',
+      },
+      {
+        label: 'Daily allowance',
+        value: overallHealth.dailyAllowance == null ? '--' : formatCurrency(overallHealth.dailyAllowance),
+        hint: overallHealth.key === 'over_budget' ? 'Needs correction' : 'Left per day',
+      },
+      {
+        label: 'Net this month',
+        value: financialHealth.netAmount == null ? '--' : formatCurrency(financialHealth.netAmount),
+        hint: financialHealth.key === 'negative_cash_flow'
+          ? 'Expenses above income'
+          : 'Income minus spend',
+      },
+    ]
+
+  return {
+    ...overallHealth,
+    badge: overallHealth.label,
+    value: overallHealth.primaryValue,
+    progressWidth: `${overallHealth.progressPercentage}%`,
+    budget,
+    spent,
+    income: income ?? 0,
+    remaining: overallHealth.remaining,
+    net,
+    daysRemaining: overallHealth.daysRemaining,
+    hasBudget,
+    isOverBudget: overallHealth.key === 'over_budget',
+    isNearLimit: overallHealth.key === 'near_limit',
+    metrics,
+  }
+}
+
+function buildLiveCategoryCards(categoryStatuses = []) {
+  return categoryStatuses.map((item) => {
+    const presentation = getCategoryPresentation({
+      name: item.category_name,
+      icon: item.category_icon,
+      kind: 'expense',
+    })
+    const amount = Number(item.spent ?? 0)
+    const categoryHealth = buildCategoryBudgetHealth({
+      monthlyLimit: item.monthly_limit,
+      spent: item.spent,
+      actualsAvailable: true,
+    })
+
+    return {
+      id: item.category_id ?? item.category_name ?? `${item.category_name}-${amount}`,
+      name: presentation.label,
+      symbol: presentation.symbol,
+      color: presentation.color,
+      soft: presentation.soft,
+      progress: categoryHealth.progressPercentage,
+      amount,
+      monthlyLimit: Number(item.monthly_limit ?? 0) > 0 ? Number(item.monthly_limit) : null,
+      remainingAmount: categoryHealth.remainingAmount,
+      note: categoryHealth.remainingText,
+      statusLabel: categoryHealth.label,
+      statusTone: categoryHealth.tone,
+    }
+  })
+}
+
+export function buildDerivedCategoryCards(expenses = []) {
+  const grouped = new Map()
+
+  expenses.forEach((expense) => {
+    const amount = Number(expense.amount ?? 0)
+    const key = expense.category_id ?? expense.category_name ?? 'uncategorized'
+    const displayName = expense.category_name
+      && String(expense.category_name).trim() !== ''
+      ? String(expense.category_name).trim()
+      : ''
+    const existing = grouped.get(key)
+    const current = existing ?? {
+      category_name: displayName,
+      category_icon: expense.category_icon ?? null,
+      total_amount: 0,
+      count: 0,
+    }
+    if (!current.category_icon && expense.category_icon) {
+      current.category_icon = expense.category_icon
+    }
+
+    current.total_amount += amount
+    current.count += 1
+    grouped.set(key, current)
+  })
+
+  const breakdown = Array.from(grouped.entries())
+    .map(([key, item]) => ({
+      category_id: key,
+      category_name: item.category_name,
+      category_icon: item.category_icon ?? null,
+      total_amount: Number(item.total_amount.toFixed(2)),
+      count: item.count,
+    }))
+    .sort((left, right) => right.total_amount - left.total_amount)
+
+  const totalExpenses = breakdown.reduce((sum, item) => sum + Number(item.total_amount ?? 0), 0)
+
+  return breakdown.map((item) => {
+    const presentation = getCategoryPresentation({
+      name: item.category_name,
+      icon: item.category_icon,
+      kind: 'expense',
+    })
+    const amount = Number(item.total_amount ?? 0)
+    const share = totalExpenses > 0 ? (amount / totalExpenses) * 100 : 0
+
+    return {
+      id: item.category_id ?? item.category_name ?? `${item.category_name}-${amount}`,
+      name: presentation.label,
+      symbol: presentation.symbol,
+      color: presentation.color,
+      soft: presentation.soft,
+      progress: Math.min(share, 100),
+      amount,
+      monthlyLimit: null,
+      remainingAmount: null,
+      note: `${Math.round(share) || 0}% of spend`,
+    }
+  })
+}
+
+export function buildSampleCategoryCards(categoryBudgets = []) {
+  return categoryBudgets.map((item) => {
+    const presentation = getCategoryPresentation({ name: item.name, kind: 'expense' })
+    const categoryHealth = buildCategoryBudgetHealth({
+      monthlyLimit: item.budget,
+      spent: item.spent,
+      actualsAvailable: true,
+    })
+    return {
+      id: item.id,
+      name: presentation.label,
+      symbol: presentation.symbol,
+      color: presentation.color,
+      soft: presentation.soft,
+      progress: categoryHealth.progressPercentage,
+      amount: item.spent,
+      monthlyLimit: item.budget,
+      remainingAmount: categoryHealth.remainingAmount,
+      note: categoryHealth.remainingText,
+      statusLabel: categoryHealth.label,
+      statusTone: categoryHealth.tone,
+    }
+  })
+}
+
+export function getCategoryCards(categoryStatuses, expenses = [], derivedCategoryCards = null) {
+  return hasBudgetedCategoryStatuses(categoryStatuses)
+    ? buildLiveCategoryCards(categoryStatuses)
+    : Array.isArray(derivedCategoryCards) ? derivedCategoryCards : buildDerivedCategoryCards(expenses)
+}
+
+export function getBudgetPressureHighlight(summary, expenses = [], derivedCategoryCards = null) {
+  const spendShareCards = Array.isArray(derivedCategoryCards)
+    ? derivedCategoryCards
+    : buildDerivedCategoryCards(expenses)
+
+  return buildSharedBudgetPressureHighlight({
+    categoryStatuses: summary?.category_statuses,
+    fallbackSpendCards: spendShareCards.map((card) => ({
+      name: card.name,
+      note: card.note,
+      progress: card.progress,
+      amount: card.amount,
+    })),
+  })
+}
+
+export function getTopSavingsGoal(savingsGoals) {
+  return [...(savingsGoals?.goals ?? [])]
+    .filter((goal) => !goal.archived)
+    .sort((left, right) => {
+      const leftComplete = left.budget_context?.status === 'complete'
+      const rightComplete = right.budget_context?.status === 'complete'
+      if (leftComplete !== rightComplete) return leftComplete ? 1 : -1
+      const severity = { over_budget: 5, overdue: 5, tight: 4, no_budget: 3, ready: 2, complete: 1 }
+      const severityDifference = (severity[right.budget_context?.status] ?? 0) - (severity[left.budget_context?.status] ?? 0)
+      if (severityDifference) return severityDifference
+      return String(left.target_date).localeCompare(String(right.target_date))
+    })[0] ?? null
+}
+
+export function buildDemoRecentCashFlow(summary) {
+  const monthlyIncome = getSafeMoneyNumber(summary?.total_income)
+  const monthlyExpenses = getSafeMoneyNumber(summary?.total_expenses)
+  return [
+    { month: '2026-01-01', label: 'Jan', incomeAmount: monthlyIncome * 0.95, expenseAmount: monthlyExpenses * 0.88, netAmount: Number((monthlyIncome * 0.95 - monthlyExpenses * 0.88).toFixed(2)) },
+    { month: '2026-02-01', label: 'Feb', incomeAmount: monthlyIncome * 1.02, expenseAmount: monthlyExpenses * 1.05, netAmount: Number((monthlyIncome * 1.02 - monthlyExpenses * 1.05).toFixed(2)) },
+    { month: '2026-03-01', label: 'Mar', incomeAmount: monthlyIncome, expenseAmount: monthlyExpenses, netAmount: Number((monthlyIncome - monthlyExpenses).toFixed(2)) },
+  ]
+}
+
+export function getPreviewCategories(categoryCards = [], limit = DEFAULT_CATEGORY_PREVIEW_LIMIT) {
+  return [...categoryCards]
+    .sort((left, right) => {
+      const leftBudgeted = left.monthlyLimit != null && Number(left.monthlyLimit) > 0
+      const rightBudgeted = right.monthlyLimit != null && Number(right.monthlyLimit) > 0
+      if (leftBudgeted && rightBudgeted) {
+        return (Number(right.progress) || 0) - (Number(left.progress) || 0)
+      }
+      if (leftBudgeted !== rightBudgeted) return leftBudgeted ? -1 : 1
+      return (Number(right.amount) || 0) - (Number(left.amount) || 0)
+    })
+    .slice(0, limit)
+}
+
+export function mergeRowsById(...groups) {
+  const merged = new Map()
+
+  groups.flat().forEach((row, index) => {
+    if (!row) return
+    const key = row.id == null ? `fallback-${index}` : String(row.id)
+    if (!merged.has(key)) merged.set(key, row)
+  })
+
+  return Array.from(merged.values())
+}
+
+export function buildDashboardLivePaths(month, { activityLimit = DEFAULT_RECENT_ACTIVITY_LIMIT } = {}) {
+  const cashFlowStart = shiftMonth(month, -2) || month
+  const encodedMonth = encodeURIComponent(month)
+  const encodedCashFlowStart = encodeURIComponent(cashFlowStart)
+
+  return {
+    summary: `/api/budget/summary?month=${encodedMonth}`,
+    cashFlowExpenses: `/api/expenses?from=${encodedCashFlowStart}`,
+    recentExpenses: `/api/expenses?limit=${activityLimit}`,
+    cashFlowIncome: `/api/income?from=${encodedCashFlowStart}`,
+    recentIncome: `/api/income?limit=${activityLimit}`,
+    savingsGoals: `/api/savings-goals?month=${encodedMonth}`,
+  }
+}

--- a/nextjs/src/lib/dashboardModels.js
+++ b/nextjs/src/lib/dashboardModels.js
@@ -341,16 +341,32 @@ export function sortRowsByDateDesc(rows = []) {
     .map(({ row }) => row)
 }
 
+function getMonthEndDate(month) {
+  const nextMonth = shiftMonth(month, 1)
+  if (!nextMonth) return null
+
+  const [year, monthNumber] = nextMonth.split('-').map(Number)
+  const endDate = new Date(Date.UTC(year, monthNumber - 1, 0, 12))
+
+  return [
+    endDate.getUTCFullYear(),
+    String(endDate.getUTCMonth() + 1).padStart(2, '0'),
+    String(endDate.getUTCDate()).padStart(2, '0'),
+  ].join('-')
+}
+
 export function buildDashboardLivePaths(month, { activityLimit = DEFAULT_RECENT_ACTIVITY_LIMIT } = {}) {
   const cashFlowStart = shiftMonth(month, -2) || month
+  const cashFlowEnd = getMonthEndDate(month) || month
   const encodedMonth = encodeURIComponent(month)
   const encodedCashFlowStart = encodeURIComponent(cashFlowStart)
+  const encodedCashFlowEnd = encodeURIComponent(cashFlowEnd)
 
   return {
     summary: `/api/budget/summary?month=${encodedMonth}`,
-    cashFlowExpenses: `/api/expenses?from=${encodedCashFlowStart}`,
+    cashFlowExpenses: `/api/expenses?from=${encodedCashFlowStart}&to=${encodedCashFlowEnd}`,
     recentExpenses: `/api/expenses?limit=${activityLimit}`,
-    cashFlowIncome: `/api/income?from=${encodedCashFlowStart}`,
+    cashFlowIncome: `/api/income?from=${encodedCashFlowStart}&to=${encodedCashFlowEnd}`,
     recentIncome: `/api/income?limit=${activityLimit}`,
     savingsGoals: `/api/savings-goals?month=${encodedMonth}`,
   }

--- a/nextjs/src/lib/dashboardModels.js
+++ b/nextjs/src/lib/dashboardModels.js
@@ -321,7 +321,7 @@ export function mergeRowsById(...groups) {
   groups.flat().forEach((row, index) => {
     if (!row) return
     const key = row.id == null ? `fallback-${index}` : String(row.id)
-    if (!merged.has(key)) merged.set(key, row)
+    merged.set(key, row)
   })
 
   return Array.from(merged.values())

--- a/nextjs/src/lib/dashboardModels.js
+++ b/nextjs/src/lib/dashboardModels.js
@@ -327,6 +327,20 @@ export function mergeRowsById(...groups) {
   return Array.from(merged.values())
 }
 
+export function sortRowsByDateDesc(rows = []) {
+  return [...rows]
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.row?.date ?? left.row?.created_at ?? '')
+      const rightTime = Date.parse(right.row?.date ?? right.row?.created_at ?? '')
+      const leftSortable = Number.isNaN(leftTime) ? Number.NEGATIVE_INFINITY : leftTime
+      const rightSortable = Number.isNaN(rightTime) ? Number.NEGATIVE_INFINITY : rightTime
+      const dateDifference = rightSortable - leftSortable
+      return dateDifference || left.index - right.index
+    })
+    .map(({ row }) => row)
+}
+
 export function buildDashboardLivePaths(month, { activityLimit = DEFAULT_RECENT_ACTIVITY_LIMIT } = {}) {
   const cashFlowStart = shiftMonth(month, -2) || month
   const encodedMonth = encodeURIComponent(month)

--- a/nextjs/src/lib/insightsViewModels.js
+++ b/nextjs/src/lib/insightsViewModels.js
@@ -1,0 +1,441 @@
+import {
+  formatCurrency,
+  formatPercentage,
+} from './financeUtils'
+
+export const DONUT_VIEWBOX = 520
+export const DONUT_CENTER = DONUT_VIEWBOX / 2
+export const DONUT_RADIUS = 164
+const DONUT_STROKE_WIDTH = 42
+const DONUT_OUTER_RADIUS = DONUT_RADIUS + (DONUT_STROKE_WIDTH / 2)
+const DONUT_MARKER_RADIUS = DONUT_OUTER_RADIUS + 42
+
+export const CASHFLOW_WIDTH = 560
+export const CASHFLOW_HEIGHT = 344
+export const CASHFLOW_INSET_X = 32
+const CASHFLOW_INSET_TOP = 24
+const CASHFLOW_INSET_BOTTOM = 52
+const CASHFLOW_BASELINE_RATIO = 0.53
+
+const CALENDAR_WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+const RHYTHM_TICK_DAYS = [1, 7, 14, 21, 28]
+
+export function getActiveBreakdownItems(snapshot, viewMode = 'expenses') {
+  if (!snapshot) return []
+  return viewMode === 'income'
+    ? (snapshot.incomeBreakdown ?? [])
+    : (snapshot.expenseBreakdown ?? [])
+}
+
+export function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function formatSignedCurrency(value) {
+  const amount = Number(value ?? 0)
+  const sign = amount > 0 ? '+' : amount < 0 ? '-' : ''
+  return `${sign}${formatCurrency(Math.abs(amount))}`
+}
+
+function formatSignedPercentage(value) {
+  const amount = Number(value ?? 0)
+  const sign = amount > 0 ? '+' : amount < 0 ? '-' : ''
+  const absolute = Math.abs(amount)
+  const decimals = absolute >= 10 || Number.isInteger(absolute) ? 0 : 1
+  return `${sign}${absolute.toFixed(decimals)}%`
+}
+
+export function getMetricValue(metric) {
+  if (metric.id === 'budget-left' && metric.currentAmount == null) return 'No budget'
+  return formatCurrency(metric.currentAmount ?? 0)
+}
+
+export function getMetricDeltaValue(metric) {
+  if (metric.id === 'budget-left' && metric.currentAmount == null) return 'Set budget'
+  if (metric.deltaAmount == null) return 'No baseline'
+  if (metric.deltaAmount === 0) return 'Flat'
+  if ((metric.previousAmount ?? 0) > 0 && metric.deltaPercentage != null) {
+    return formatSignedPercentage(metric.deltaPercentage)
+  }
+  return formatSignedCurrency(metric.deltaAmount)
+}
+
+export function getMetricDeltaContext(metric) {
+  if (metric.id === 'budget-left' && metric.currentAmount == null) return null
+  if (metric.deltaAmount == null) return null
+  return 'vs last month'
+}
+
+export function getMetricAccent(metricId) {
+  if (metricId === 'income') return '\u2197'
+  if (metricId === 'expenses') return '\u2198'
+  if (metricId === 'net') return '\u223F'
+  if (metricId === 'budget-left') return '\u25CE'
+  return '\u2022'
+}
+
+export function pickTopExpensesFromDetails(details = [], limit = 10) {
+  if (!Array.isArray(details) || !details.length) return []
+  return [...details]
+    .sort((left, right) => Number(right.amount ?? 0) - Number(left.amount ?? 0))
+    .slice(0, limit)
+}
+
+export function getBudgetUsageHeadline(budgetHealth) {
+  if (!budgetHealth || budgetHealth.budgetAmount == null) return 'Budget not set'
+  return `${Math.round(budgetHealth.progressValue ?? 0)}% used`
+}
+
+function polarToCartesian(angle, radius) {
+  const radians = ((angle - 90) * Math.PI) / 180
+  return {
+    x: DONUT_CENTER + (radius * Math.cos(radians)),
+    y: DONUT_CENTER + (radius * Math.sin(radians)),
+  }
+}
+
+function describeArc(startAngle, endAngle) {
+  const start = polarToCartesian(endAngle, DONUT_RADIUS)
+  const end = polarToCartesian(startAngle, DONUT_RADIUS)
+  const largeArcFlag = endAngle - startAngle <= 180 ? '0' : '1'
+
+  return [
+    'M',
+    start.x.toFixed(3),
+    start.y.toFixed(3),
+    'A',
+    DONUT_RADIUS,
+    DONUT_RADIUS,
+    0,
+    largeArcFlag,
+    0,
+    end.x.toFixed(3),
+    end.y.toFixed(3),
+  ].join(' ')
+}
+
+function normalizeAngle(angle) {
+  const mod = angle % 360
+  return mod < 0 ? mod + 360 : mod
+}
+
+function getMinMarkerGap(count) {
+  if (count <= 1) return 360
+  if (count <= 2) return 110
+  if (count <= 3) return 70
+  if (count <= 4) return 52
+  if (count <= 5) return 38
+  return Math.max(Math.floor(360 / count) - 4, 28)
+}
+
+function resolveMarkerAngles(rawAngles, minGap) {
+  const count = rawAngles.length
+  if (count === 0) return []
+  if (count === 1) return [normalizeAngle(rawAngles[0])]
+
+  const sorted = rawAngles
+    .map((angle, index) => ({ angle: normalizeAngle(angle), index }))
+    .sort((left, right) => left.angle - right.angle)
+
+  for (let pass = 0; pass < 8; pass += 1) {
+    let moved = false
+
+    for (let i = 1; i < count; i += 1) {
+      const gap = sorted[i].angle - sorted[i - 1].angle
+      if (gap < minGap) {
+        sorted[i].angle = sorted[i - 1].angle + minGap
+        moved = true
+      }
+    }
+
+    const wrapGap = (360 + sorted[0].angle) - sorted[count - 1].angle
+    if (wrapGap < minGap) {
+      const shift = (minGap - wrapGap) / 2 + 0.01
+      sorted[count - 1].angle -= shift
+      sorted[0].angle += shift
+      moved = true
+    }
+
+    for (let i = count - 2; i >= 0; i -= 1) {
+      const gap = sorted[i + 1].angle - sorted[i].angle
+      if (gap < minGap) {
+        sorted[i].angle = sorted[i + 1].angle - minGap
+        moved = true
+      }
+    }
+
+    if (!moved) break
+  }
+
+  sorted.forEach((item) => {
+    item.angle = normalizeAngle(item.angle)
+    if (item.angle > 170 && item.angle < 190) {
+      item.angle = item.angle <= 180 ? 168 : 192
+    }
+  })
+
+  const result = new Array(count)
+  sorted.forEach(({ angle, index }) => { result[index] = normalizeAngle(angle) })
+  return result
+}
+
+export function buildDonutSegments(items = []) {
+  const total = items.reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
+  if (!total) return []
+
+  const gapAngle = items.length > 1 ? 3.2 : 0
+  const midAngles = []
+  let currentAngle = 0
+
+  const rawSegments = items.map((item, index) => {
+    const sliceAngle = (Number(item.amount ?? 0) / total) * 360
+    const startAngle = currentAngle + (gapAngle / 2)
+    const endAngle = currentAngle + sliceAngle - (gapAngle / 2)
+    const safeEndAngle = endAngle <= startAngle
+      ? startAngle + Math.min(Math.max(sliceAngle, 1), 359.5)
+      : Math.min(endAngle, startAngle + 359.5)
+    const midAngle = startAngle + ((safeEndAngle - startAngle) / 2)
+    midAngles.push(midAngle)
+    currentAngle += sliceAngle
+
+    return {
+      ...item,
+      index,
+      path: describeArc(startAngle, safeEndAngle),
+      animationDelay: `${index * 90}ms`,
+    }
+  })
+
+  const resolvedAngles = resolveMarkerAngles(midAngles, getMinMarkerGap(items.length))
+
+  return rawSegments.map((segment, index) => {
+    const angle = resolvedAngles[index]
+    const anchor = polarToCartesian(angle, DONUT_MARKER_RADIUS)
+    return {
+      ...segment,
+      markerAngle: angle,
+      x: anchor.x,
+      y: anchor.y,
+      markerLeft: `${(anchor.x / DONUT_VIEWBOX) * 100}%`,
+      markerTop: `${(anchor.y / DONUT_VIEWBOX) * 100}%`,
+    }
+  })
+}
+
+function buildSmoothPath(points = []) {
+  if (!points.length) return ''
+  return points.reduce((path, point, index) => {
+    if (index === 0) return `M ${point.x.toFixed(2)} ${point.y.toFixed(2)}`
+    const previous = points[index - 1]
+    const controlX = (previous.x + point.x) / 2
+    return `${path} C ${controlX.toFixed(2)} ${previous.y.toFixed(2)}, ${controlX.toFixed(2)} ${point.y.toFixed(2)}, ${point.x.toFixed(2)} ${point.y.toFixed(2)}`
+  }, '')
+}
+
+export function buildCashFlowGeometry(series = []) {
+  const plotBottom = CASHFLOW_HEIGHT - CASHFLOW_INSET_BOTTOM
+  const chartHeight = plotBottom - CASHFLOW_INSET_TOP
+  const baselineY = CASHFLOW_INSET_TOP + (chartHeight * CASHFLOW_BASELINE_RATIO)
+  const innerWidth = CASHFLOW_WIDTH - (CASHFLOW_INSET_X * 2)
+  const groupWidth = innerWidth / Math.max(series.length, 1)
+  const barWidth = clamp(groupWidth * 0.28, 18, 30)
+  const maxBarValue = Math.max(...series.flatMap((item) => [Number(item.incomeAmount ?? 0), Number(item.expenseAmount ?? 0)]), 1)
+  const maxNetValue = Math.max(...series.map((item) => Math.abs(Number(item.netAmount ?? 0))), 1)
+  const topBandHeight = baselineY - CASHFLOW_INSET_TOP - 8
+  const bottomBandHeight = plotBottom - baselineY - 10
+  const netBandHeight = Math.min(topBandHeight, bottomBandHeight) + 14
+  const guides = [
+    baselineY - (topBandHeight * 0.82),
+    baselineY - (topBandHeight * 0.48),
+    baselineY,
+    baselineY + (bottomBandHeight * 0.48),
+    baselineY + (bottomBandHeight * 0.82),
+  ]
+
+  const groups = series.map((item, index) => {
+    const centerX = CASHFLOW_INSET_X + (groupWidth * index) + (groupWidth / 2)
+    const incomeHeight = (Number(item.incomeAmount ?? 0) / maxBarValue) * topBandHeight
+    const expenseHeight = (Number(item.expenseAmount ?? 0) / maxBarValue) * bottomBandHeight
+    const visibleTop = clamp(Math.min(baselineY, baselineY - incomeHeight, baselineY - ((Number(item.netAmount ?? 0) / maxNetValue) * netBandHeight)) - 14, CASHFLOW_INSET_TOP + 4, plotBottom - 80)
+    const visibleBottom = clamp(Math.max(baselineY + expenseHeight, baselineY - ((Number(item.netAmount ?? 0) / maxNetValue) * netBandHeight)) + 14, CASHFLOW_INSET_TOP + 56, plotBottom + 6)
+    return {
+      ...item,
+      centerX,
+      barX: centerX - (barWidth / 2),
+      barWidth,
+      incomeY: baselineY - incomeHeight,
+      incomeHeight,
+      expenseY: baselineY,
+      expenseHeight,
+      netY: baselineY - ((Number(item.netAmount ?? 0) / maxNetValue) * netBandHeight),
+      labelY: CASHFLOW_HEIGHT - 10,
+      interactionX: centerX - (groupWidth / 2),
+      interactionY: visibleTop,
+      interactionWidth: groupWidth,
+      interactionHeight: visibleBottom - visibleTop,
+    }
+  })
+
+  return {
+    baselineY,
+    guides,
+    groups,
+    maxBarValue,
+    linePath: buildSmoothPath(groups.map((item) => ({ x: item.centerX, y: item.netY }))),
+  }
+}
+
+export function buildCalendarGrid(series = [], month) {
+  if (!series.length || !month) return { weeks: [], weekdayLabels: CALENDAR_WEEKDAYS }
+  const monthDate = new Date(`${month}T12:00:00Z`)
+  if (Number.isNaN(monthDate.getTime())) return { weeks: [], weekdayLabels: CALENDAR_WEEKDAYS }
+
+  const firstDay = new Date(Date.UTC(monthDate.getUTCFullYear(), monthDate.getUTCMonth(), 1, 12)).getUTCDay()
+  const maxAmount = Math.max(...series.map((item) => Number(item.amount ?? 0)), 1)
+  const cells = [
+    ...Array.from({ length: firstDay }, (_, index) => ({ key: `blank-start-${index}`, isBlank: true })),
+    ...series.map((item) => {
+      const ratio = Number(item.amount ?? 0) / maxAmount
+      let intensity = 0
+      if (item.amount > 0.001) intensity = 1
+      if (ratio >= 0.24) intensity = 2
+      if (ratio >= 0.5) intensity = 3
+      if (ratio >= 0.78) intensity = 4
+      return { ...item, intensity, isBlank: false }
+    }),
+  ]
+
+  while (cells.length % 7 !== 0) {
+    cells.push({ key: `blank-end-${cells.length}`, isBlank: true })
+  }
+
+  return {
+    weekdayLabels: CALENDAR_WEEKDAYS,
+    weeks: Array.from({ length: cells.length / 7 }, (_, index) => cells.slice(index * 7, (index + 1) * 7)),
+  }
+}
+
+export function buildRhythmBars(series = []) {
+  const maxAmount = Math.max(...series.map((item) => Number(item.amount ?? 0)), 1)
+  const lastDay = series.at(-1)?.day ?? 0
+  const tickDays = [...new Set([...RHYTHM_TICK_DAYS, lastDay].filter((day) => day > 0 && day <= lastDay))]
+  return {
+    tickDays,
+    columns: series.map((item) => ({
+      ...item,
+      heightRatio: maxAmount > 0 ? Number(item.amount ?? 0) / maxAmount : 0,
+    })),
+  }
+}
+
+export function buildDailyDetailMap(entries = []) {
+  return entries.reduce((map, entry) => {
+    if (!entry?.key) return map
+    if (!map[entry.key]) map[entry.key] = []
+    map[entry.key].push(entry)
+    return map
+  }, {})
+}
+
+export function buildCumulativeSeries(series = []) {
+  let running = 0
+  return series.map((item) => {
+    running += Number(item?.amount ?? 0)
+    return {
+      day: Number(item?.day ?? 0),
+      amount: Number(running.toFixed(2)),
+    }
+  })
+}
+
+export function getMonthLength(month) {
+  if (!month) return 31
+  const date = new Date(`${month}T12:00:00Z`)
+  if (Number.isNaN(date.getTime())) return 31
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0)).getUTCDate()
+}
+
+export function getMonthShortLabel(month) {
+  if (!month) return 'Month'
+  const date = new Date(`${month}T12:00:00Z`)
+  if (Number.isNaN(date.getTime())) return 'Month'
+  return date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' })
+}
+
+export function getDefaultSelectedDay(dailySpend) {
+  if (dailySpend?.peakDay?.key) return dailySpend.peakDay.key
+  const firstActiveDay = dailySpend?.series?.find((item) => Number(item.amount ?? 0) > 0)
+  return firstActiveDay?.key ?? null
+}
+
+export function getCashFlowHighlights(cashFlowSeries = [], focusCashGroup = null) {
+  const positiveCashMonths = cashFlowSeries.filter((item) => Number(item.netAmount ?? 0) >= 0).length
+  const strongestCashMonth = cashFlowSeries.reduce((best, item) => (
+    !best || Number(item.netAmount ?? 0) > Number(best.netAmount ?? 0) ? item : best
+  ), null)
+  const highestExpenseMonth = cashFlowSeries.reduce((best, item) => (
+    !best || Number(item.expenseAmount ?? 0) > Number(best.expenseAmount ?? 0) ? item : best
+  ), null)
+  const focusSavingsRate = focusCashGroup && Number(focusCashGroup.incomeAmount ?? 0) > 0
+    ? (Number(focusCashGroup.netAmount ?? 0) / Number(focusCashGroup.incomeAmount ?? 0)) * 100
+    : null
+  const cashFlowFocusTone = focusCashGroup && Number(focusCashGroup.netAmount ?? 0) < 0 ? 'negative' : 'positive'
+  const cashFlowHealthLabel = cashFlowSeries.length && positiveCashMonths === cashFlowSeries.length
+    ? 'Every month positive'
+    : `${positiveCashMonths}/${cashFlowSeries.length} positive months`
+  const cashFlowHealthCopy = focusCashGroup
+    ? `${focusCashGroup.label} kept ${formatPercentage(focusSavingsRate ?? 0)} of income after expenses.`
+    : 'Cash-flow highlights appear after a few months of activity.'
+
+  return {
+    cashFlowFocusTone,
+    cashFlowHealthCopy,
+    cashFlowHealthLabel,
+    focusSavingsRate,
+    highestExpenseMonth,
+    positiveCashMonths,
+    strongestCashMonth,
+  }
+}
+
+export function getMoverScaleMax(categoryMovers = []) {
+  return Math.max(
+    ...categoryMovers.flatMap((entry) => [Number(entry.amount ?? 0), Number(entry.previousAmount ?? 0)]),
+    1
+  )
+}
+
+export function getFilenameFromDisposition(value, fallback) {
+  if (!value) return fallback
+  const filenameStarMatch = value.match(/(?:^|;)\s*filename\*\s*=\s*([^;]+)/i)
+  const filenameMatch = value.match(/(?:^|;)\s*filename\s*=\s*("[^"]*"|[^;]+)/i)
+  const candidate = filenameStarMatch
+    ? decodeDispositionFilename(filenameStarMatch[1])
+    : decodeDispositionFilename(filenameMatch?.[1])
+  return sanitizeDownloadFilename(candidate, fallback)
+}
+
+function decodeDispositionFilename(value) {
+  if (!value) return ''
+  const text = value.trim().replace(/^"|"$/g, '')
+  const encodedMatch = text.match(/^([^']*)'[^']*'(.*)$/)
+  if (!encodedMatch) return text
+
+  try {
+    return decodeURIComponent(encodedMatch[2])
+  } catch {
+    return ''
+  }
+}
+
+function sanitizeDownloadFilename(value, fallback) {
+  const cleaned = String(value || '')
+    .replace(/[\u0000-\u001f\u007f]+/g, '')
+    .replace(/[\\/]+/g, '-')
+    .replace(/[:*?"<>|]+/g, '_')
+    .trim()
+    .slice(0, 120)
+
+  if (!cleaned || cleaned === '.' || cleaned === '..' || !/[A-Za-z0-9]/.test(cleaned)) return fallback
+  return cleaned
+}

--- a/nextjs/src/lib/transactionQuery.js
+++ b/nextjs/src/lib/transactionQuery.js
@@ -1,0 +1,75 @@
+import { normalizeDate, normalizeMonth } from './budget'
+
+const MAX_TRANSACTION_LIST_LIMIT = 500
+
+function shiftMonth(month, offset = 1) {
+  const date = new Date(`${month}T12:00:00Z`)
+  if (Number.isNaN(date.getTime())) return null
+  date.setUTCMonth(date.getUTCMonth() + offset)
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-01`
+}
+
+function parseLimit(value) {
+  if (value == null || value === '') return null
+  if (!/^\d+$/.test(String(value))) return undefined
+
+  const limit = Number(value)
+  if (!Number.isSafeInteger(limit) || limit <= 0) return undefined
+  return Math.min(limit, MAX_TRANSACTION_LIST_LIMIT)
+}
+
+export function buildTransactionListQuery(searchParams, { dateColumn, firstParameterIndex = 1 } = {}) {
+  const monthValue = searchParams.get('month')
+  const fromValue = searchParams.get('from')
+  const toValue = searchParams.get('to')
+  const limitValue = searchParams.get('limit')
+
+  if (monthValue && (fromValue || toValue)) {
+    return { error: 'Use either month or from/to, not both' }
+  }
+
+  const clauses = []
+  const values = []
+  let nextIndex = firstParameterIndex
+
+  if (monthValue) {
+    const month = normalizeMonth(monthValue)
+    const endMonth = month ? shiftMonth(month, 1) : null
+    if (!month || !endMonth) return { error: 'Valid month is required' }
+
+    clauses.push(`${dateColumn} >= $${nextIndex}`)
+    values.push(month)
+    nextIndex += 1
+    clauses.push(`${dateColumn} < $${nextIndex}`)
+    values.push(endMonth)
+    nextIndex += 1
+  } else {
+    if (fromValue) {
+      const from = normalizeDate(fromValue)
+      if (!from) return { error: 'Valid from date is required' }
+      clauses.push(`${dateColumn} >= $${nextIndex}`)
+      values.push(from)
+      nextIndex += 1
+    }
+
+    if (toValue) {
+      const to = normalizeDate(toValue)
+      if (!to) return { error: 'Valid to date is required' }
+      if (values.length && fromValue && values[0] > to) {
+        return { error: 'from date must be on or before to date' }
+      }
+      clauses.push(`${dateColumn} <= $${nextIndex}`)
+      values.push(to)
+      nextIndex += 1
+    }
+  }
+
+  const limit = parseLimit(limitValue)
+  if (limit === undefined) return { error: 'Valid limit is required' }
+
+  return {
+    clauses,
+    values,
+    limitClause: limit == null ? '' : `LIMIT ${limit}`,
+  }
+}

--- a/nextjs/src/lib/transactionQuery.js
+++ b/nextjs/src/lib/transactionQuery.js
@@ -19,12 +19,15 @@ function parseLimit(value) {
 }
 
 export function buildTransactionListQuery(searchParams, { dateColumn, firstParameterIndex = 1 } = {}) {
+  const hasMonth = searchParams.has('month')
+  const hasFrom = searchParams.has('from')
+  const hasTo = searchParams.has('to')
   const monthValue = searchParams.get('month')
   const fromValue = searchParams.get('from')
   const toValue = searchParams.get('to')
   const limitValue = searchParams.get('limit')
 
-  if (monthValue && (fromValue || toValue)) {
+  if (hasMonth && (hasFrom || hasTo)) {
     return { error: 'Use either month or from/to, not both' }
   }
 
@@ -32,7 +35,7 @@ export function buildTransactionListQuery(searchParams, { dateColumn, firstParam
   const values = []
   let nextIndex = firstParameterIndex
 
-  if (monthValue) {
+  if (hasMonth) {
     const month = normalizeMonth(monthValue)
     const endMonth = month ? shiftMonth(month, 1) : null
     if (!month || !endMonth) return { error: 'Valid month is required' }
@@ -44,18 +47,20 @@ export function buildTransactionListQuery(searchParams, { dateColumn, firstParam
     values.push(endMonth)
     nextIndex += 1
   } else {
-    if (fromValue) {
-      const from = normalizeDate(fromValue)
+    let from = null
+
+    if (hasFrom) {
+      from = normalizeDate(fromValue)
       if (!from) return { error: 'Valid from date is required' }
       clauses.push(`${dateColumn} >= $${nextIndex}`)
       values.push(from)
       nextIndex += 1
     }
 
-    if (toValue) {
+    if (hasTo) {
       const to = normalizeDate(toValue)
       if (!to) return { error: 'Valid to date is required' }
-      if (values.length && fromValue && values[0] > to) {
+      if (from && from > to) {
         return { error: 'from date must be on or before to date' }
       }
       clauses.push(`${dateColumn} <= $${nextIndex}`)

--- a/nextjs/src/lib/transactionQuery.js
+++ b/nextjs/src/lib/transactionQuery.js
@@ -10,7 +10,8 @@ function shiftMonth(month, offset = 1) {
 }
 
 function parseLimit(value) {
-  if (value == null || value === '') return null
+  if (value == null) return null
+  if (value === '') return undefined
   if (!/^\d+$/.test(String(value))) return undefined
 
   const limit = Number(value)
@@ -22,6 +23,7 @@ export function buildTransactionListQuery(searchParams, { dateColumn, firstParam
   const hasMonth = searchParams.has('month')
   const hasFrom = searchParams.has('from')
   const hasTo = searchParams.has('to')
+  const hasLimit = searchParams.has('limit')
   const monthValue = searchParams.get('month')
   const fromValue = searchParams.get('from')
   const toValue = searchParams.get('to')
@@ -69,7 +71,7 @@ export function buildTransactionListQuery(searchParams, { dateColumn, firstParam
     }
   }
 
-  const limit = parseLimit(limitValue)
+  const limit = hasLimit ? parseLimit(limitValue) : null
   if (limit === undefined) return { error: 'Valid limit is required' }
 
   return {


### PR DESCRIPTION
## Description
Runs a scoped maintainability and performance pass for BudgetBuddy’s largest screens without changing product behavior.

This PR:
- Extracts Dashboard view-model/helper logic into `src/lib/dashboardModels.js`.
- Extracts Insights chart/view-model/helper logic into `src/lib/insightsViewModels.js`.
- Adds `src/lib/transactionQuery.js` for safe bounded transaction list queries.
- Wires `/api/expenses` and `/api/income` to support `month`, `from`, `to`, and `limit` while preserving old no-query behavior.
- Memoizes heavier Dashboard and Insights derived values.
- Updates API and frontend tests around the refactor and bounded Dashboard fetches.

## Related User Story / Issue
Fixes #77

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Backend / API change
- [ ] UI change
- [ ] Database change
- [ ] Documentation
- [x] Refactor

## How Has This Been Tested?
- [X] GitHub Actions / CI tests passed
- [X] Manual testing performed
- [ ] Not tested locally

### Test Notes
Local automated verification passed:

- `npx jest --coverage=false --runInBand __tests__/expenses.test.js __tests__/income.test.js __tests__/frontend/dashboard-view.test.js __tests__/frontend/insights-view.test.js`
- `npx jest --coverage=false --runInBand`
- `npm run build`

## UI Changes (if applicable)
- [x] No UI changes
- [ ] UI updated (add screenshots if needed)

## Notes for Reviewers
This is intentionally scoped to maintainability/performance, not product behavior or visual redesign.

A few review anchors:
- No-query `/api/expenses` and `/api/income` behavior should remain unchanged.
- New query params are additive and validated through `transactionQuery`.
- Dashboard now fetches bounded transaction data: recent rows for activity plus a three-month window for cash flow.
- Dashboard and Insights file-size reductions come from moving pure helper/model logic into `src/lib`, not from removing behavior.
- No global CSS, Planner, Transactions, package, or lockfile changes are intended.

## Checklist
- [x] Linked to a user story or issue
- [X] Code builds / tests pass in CI
- [X] Ready for review
