### PR TITLE
Allow cents in Dashboard monthly budget editor

### DIFF
--- a/nextjs/__tests__/budget.test.js
+++ b/nextjs/__tests__/budget.test.js
@@ -196,6 +196,36 @@ describe('POST /api/budget', () => {
     })
   })
 
+  it('accepts a two-decimal overall monthly budget', async () => {
+    budget.upsertMonthlyBudget.mockResolvedValueOnce({ month: '2026-03-01', monthly_limit: '49.23', notified: false })
+    budget.evaluateThresholdForMonth.mockResolvedValueOnce({
+      notified: false,
+      budget_alert: null,
+    })
+    budget.getMonthlyBudgetConfig.mockResolvedValueOnce({
+      month: '2026-03-01',
+      monthly_limit: '49.23',
+      notified: false,
+      category_budgets: [],
+    })
+
+    await testApiHandler({
+      appHandler: budgetHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ month: '2026-03-01', monthly_limit: 49.23 }))
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+          month: '2026-03-01',
+          monthly_limit: '49.23',
+          notified: false,
+          budget_alert: null,
+          category_budgets: [],
+        })
+        expect(budget.upsertMonthlyBudget).toHaveBeenCalledWith('uid', '2026-03-01', 49.23)
+      }
+    })
+  })
+
   it('upserts category budgets without requiring an overall monthly limit', async () => {
     budget.getOwnedOrGlobalCategoriesByIds.mockResolvedValueOnce([{ id: FOOD_CATEGORY_ID, name: 'Food', icon: '🍔' }])
     budget.upsertCategoryBudgets.mockResolvedValueOnce([{ category_id: FOOD_CATEGORY_ID, month: '2026-03-01', monthly_limit: '40.00' }])
@@ -308,6 +338,18 @@ describe('POST /api/budget', () => {
         const res = await fetch(post({ month: '2026-03-01', monthly_limit: 'abc' }))
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('monthly_limit must be a valid positive money amount')
+      }
+    })
+  })
+
+  it('returns 400 when monthly_limit has more than two decimal places', async () => {
+    await testApiHandler({
+      appHandler: budgetHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ month: '2026-03-01', monthly_limit: '1.999' }))
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('monthly_limit must be a valid positive money amount')
+        expect(budget.upsertMonthlyBudget).not.toHaveBeenCalled()
       }
     })
   })

--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -150,6 +150,7 @@ const {
   default: DashboardView,
   buildDerivedCategoryCards,
   getBudgetCtaLabel,
+  getBudgetDraftValidationMessage,
   getBudgetHintText,
   getBudgetHudModel,
   getBudgetPressureHighlight,
@@ -286,6 +287,23 @@ describe('getBudgetHintText', () => {
       monthly_limit: '125.00',
       total_budget: '125.00',
     })).toBe('Current limit: $125.00. Changes take effect immediately.')
+  })
+})
+
+describe('getBudgetDraftValidationMessage', () => {
+  it('accepts Dashboard monthly budget money drafts with up to two decimals', () => {
+    expect(getBudgetDraftValidationMessage('49')).toBe('')
+    expect(getBudgetDraftValidationMessage('49.23')).toBe('')
+    expect(getBudgetDraftValidationMessage('.25')).toBe('')
+  })
+
+  it('rejects invalid Dashboard monthly budget money drafts', () => {
+    expect(getBudgetDraftValidationMessage('1.')).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
+    expect(getBudgetDraftValidationMessage('49.234')).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
+    expect(getBudgetDraftValidationMessage('')).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
+    expect(getBudgetDraftValidationMessage('0')).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
+    expect(getBudgetDraftValidationMessage('-1')).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
+    expect(getBudgetDraftValidationMessage('abc')).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
   })
 })
 

--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -1021,4 +1021,49 @@ describe('DashboardView', () => {
     })
     expect(screen.queryByText(/Current limit:/)).toBeNull()
   })
+
+  it('shows app validation instead of saving budget drafts with more than two decimals', async () => {
+    apiGet
+      .mockResolvedValueOnce(createLiveSummary({
+        monthly_limit: '1000.00',
+        total_budget: '1000.00',
+        total_expenses: '400.00',
+        total_income: '1500.00',
+        remaining_budget: '600.00',
+        threshold_exceeded: false,
+        category_statuses: [],
+      }))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: { active_count: 0, available_after_goal_contributions: null },
+      })
+
+    await renderDashboard()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit budget' }))
+      await flushAsyncUpdates()
+    })
+
+    const budgetInput = screen.getByRole('spinbutton')
+    expect(budgetInput.form.noValidate).toBe(true)
+
+    await act(async () => {
+      fireEvent.change(budgetInput, { target: { value: '3.235' } })
+      await flushAsyncUpdates()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Update budget' }))
+      await flushAsyncUpdates()
+    })
+
+    expect(screen.getByRole('alert').textContent).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
+    expect(apiPost).not.toHaveBeenCalled()
+    expect(apiGet).toHaveBeenCalledTimes(6)
+  })
 })

--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -972,12 +972,12 @@ describe('DashboardView', () => {
         summary: { active_count: 0, available_after_goal_contributions: null },
       })
       .mockResolvedValueOnce(createLiveSummary({
-        monthly_limit: '3000.00',
-        total_budget: '3000.00',
+        monthly_limit: '49.23',
+        total_budget: '49.23',
         total_expenses: '400.00',
         total_income: '1500.00',
-        remaining_budget: '2600.00',
-        threshold_exceeded: false,
+        remaining_budget: '-350.77',
+        threshold_exceeded: true,
         category_statuses: [],
       }))
       .mockResolvedValueOnce([])
@@ -998,9 +998,11 @@ describe('DashboardView', () => {
     })
     expect(screen.getByText(/Monthly spending limit for/i)).toBeTruthy()
     expect(screen.getAllByText(TEST_CURRENT_MONTH).length).toBeGreaterThan(0)
+    expect(screen.getByRole('spinbutton').getAttribute('min')).toBe('0.01')
+    expect(screen.getByRole('spinbutton').getAttribute('step')).toBe('0.01')
 
     await act(async () => {
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '3000' } })
+      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '49.23' } })
       await flushAsyncUpdates()
     })
 
@@ -1011,7 +1013,7 @@ describe('DashboardView', () => {
 
     expect(apiPost).toHaveBeenCalledWith(
       '/api/budget',
-      { month: TEST_CURRENT_MONTH, monthly_limit: 3000 },
+      { month: TEST_CURRENT_MONTH, monthly_limit: 49.23 },
       { accessToken: 'test-token' }
     )
     await waitFor(() => {

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -664,9 +664,10 @@ export default function DashboardView() {
                 <input
                   className="input-field"
                   inputMode="decimal"
-                  min="1"
+                  min="0.01"
                   onChange={(event) => setBudgetDraft({ monthly_limit: event.target.value })}
                   placeholder="e.g. 2000"
+                  step="0.01"
                   type="number"
                   value={budgetDraft.monthly_limit}
                 />

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -62,6 +62,8 @@ import MonthPacingChart from '@/components/ui/MonthPacingChart'
 import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const ACTIVITY_PREVIEW_LIMIT = 6
+const BUDGET_DRAFT_VALIDATION_MESSAGE = 'Monthly limit must be a positive dollar amount with up to 2 decimal places.'
+const BUDGET_DRAFT_PATTERN = /^\d+(?:\.\d*)?$/
 
 export {
   buildDerivedCategoryCards,
@@ -77,6 +79,20 @@ function getErrorMessage(error) {
   if (error instanceof ApiError) return error.message
   if (error instanceof Error && error.message) return error.message
   return 'Something went wrong while loading the live snapshot.'
+}
+
+function getBudgetDraftValidationMessage(value) {
+  const rawValue = String(value ?? '').trim()
+  if (!rawValue) return BUDGET_DRAFT_VALIDATION_MESSAGE
+  if (!BUDGET_DRAFT_PATTERN.test(rawValue)) return BUDGET_DRAFT_VALIDATION_MESSAGE
+
+  const [, cents = ''] = rawValue.split('.')
+  const amount = Number(rawValue)
+  if (cents.length > 2 || !Number.isFinite(amount) || amount <= 0) {
+    return BUDGET_DRAFT_VALIDATION_MESSAGE
+  }
+
+  return ''
 }
 
 function LiveNotice({ message, onRetry }) {
@@ -245,6 +261,12 @@ export default function DashboardView() {
 
   const handleSaveBudget = async () => {
     if (isBudgetSaving) return
+    const validationMessage = getBudgetDraftValidationMessage(budgetDraft.monthly_limit)
+    if (validationMessage) {
+      setBudgetSaveError(validationMessage)
+      return
+    }
+
     setIsBudgetSaving(true)
     setBudgetSaveError('')
     try {
@@ -657,6 +679,7 @@ export default function DashboardView() {
 
             <form
               className="entry-sheet__form"
+              noValidate
               onSubmit={(event) => { event.preventDefault(); handleSaveBudget() }}
             >
               <label className="entry-sheet__field">
@@ -665,7 +688,10 @@ export default function DashboardView() {
                   className="input-field"
                   inputMode="decimal"
                   min="0.01"
-                  onChange={(event) => setBudgetDraft({ monthly_limit: event.target.value })}
+                  onChange={(event) => {
+                    setBudgetDraft({ monthly_limit: event.target.value })
+                    if (budgetSaveError) setBudgetSaveError('')
+                  }}
                   placeholder="e.g. 2000"
                   step="0.01"
                   type="number"

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -63,7 +63,7 @@ import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const ACTIVITY_PREVIEW_LIMIT = 6
 const BUDGET_DRAFT_VALIDATION_MESSAGE = 'Monthly limit must be a positive dollar amount with up to 2 decimal places.'
-const BUDGET_DRAFT_PATTERN = /^\d+(?:\.\d*)?$/
+const BUDGET_DRAFT_PATTERN = /^(?:\d+(?:\.\d{1,2})?|\.\d{1,2})$/
 
 export {
   buildDerivedCategoryCards,
@@ -81,14 +81,13 @@ function getErrorMessage(error) {
   return 'Something went wrong while loading the live snapshot.'
 }
 
-function getBudgetDraftValidationMessage(value) {
+export function getBudgetDraftValidationMessage(value) {
   const rawValue = String(value ?? '').trim()
   if (!rawValue) return BUDGET_DRAFT_VALIDATION_MESSAGE
   if (!BUDGET_DRAFT_PATTERN.test(rawValue)) return BUDGET_DRAFT_VALIDATION_MESSAGE
 
-  const [, cents = ''] = rawValue.split('.')
   const amount = Number(rawValue)
-  if (cents.length > 2 || !Number.isFinite(amount) || amount <= 0) {
+  if (!Number.isFinite(amount) || amount <= 0) {
     return BUDGET_DRAFT_VALIDATION_MESSAGE
   }
 


### PR DESCRIPTION
## Description
Allow the Dashboard monthly budget editor to accept cents by matching the Planner money input behavior. The Dashboard budget input now supports positive decimal values such as `49.23` while preserving the existing backend/shared money validation.

## Related User Story / Issue
Fixes #101

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [X] GitHub Actions / CI tests passed
- [X] Manual testing performed
- [ ] Not tested locally

### Test Notes
Verified locally with:
- `npx jest --runTestsByPath __tests__/frontend/dashboard-view.test.js __tests__/budget.test.js --runInBand`
- `npm run build`

Added coverage for Dashboard saving `49.23`, input `min="0.01"` / `step="0.01"`, `/api/budget` accepting `49.23`, and `/api/budget` rejecting `1.999`.

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Notes for Reviewers
This is intentionally scoped to the Dashboard monthly budget editor. Shared money validation and backend budget behavior were left unchanged because existing validation already supports positive values with up to two decimal places.

## Checklist
- [x] Linked to a user story or issue
- [x] Code builds / tests pass in CI
- [x] Ready for review
