### PR TITLE
Constrain transaction merchant and note text

### DIFF
--- a/nextjs/__tests__/expenses.test.js
+++ b/nextjs/__tests__/expenses.test.js
@@ -20,6 +20,10 @@ const expensesHandler = require('@/app/api/expenses/route')
 const getHandler = require('@/app/api/expenses/get/route')
 const updateHandler = require('@/app/api/expenses/update/route')
 const deleteHandler = require('@/app/api/expenses/delete/route')
+const {
+  EXPENSE_DESCRIPTION_LENGTH_MESSAGE,
+  EXPENSE_DESCRIPTION_MAX_LENGTH,
+} = require('@/lib/transactionText')
 
 const post = (body) => ({ method: 'POST', body: JSON.stringify(body), headers: { 'content-type': 'application/json' } })
 
@@ -61,6 +65,22 @@ describe('POST /api/expenses', () => {
         const res = await fetch(post({ amount: 25, date: '2026-03-01', category_id: 3 }))
         expect(res.status).toBe(201)
         expect((await res.json()).category_id).toBe(3)
+      }
+    })
+  })
+
+  it('201 - accepts a description at the merchant length limit', async () => {
+    const description = 'M'.repeat(EXPENSE_DESCRIPTION_MAX_LENGTH)
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, description }] })
+    await testApiHandler({
+      appHandler: expensesHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ amount: 25, date: '2026-03-01', description }))
+        expect(res.status).toBe(201)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('INSERT INTO public.expenses'),
+          ['uid', null, 25, description, '2026-03-01']
+        )
       }
     })
   })
@@ -142,6 +162,22 @@ describe('POST /api/expenses', () => {
         const res = await fetch(post({ amount: 25, date: 'bad-date' }))
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('Valid date is required')
+      }
+    })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('400 - rejects an over-limit description before querying', async () => {
+    await testApiHandler({
+      appHandler: expensesHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({
+          amount: 25,
+          date: '2026-03-01',
+          description: 'M'.repeat(EXPENSE_DESCRIPTION_MAX_LENGTH + 1),
+        }))
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe(EXPENSE_DESCRIPTION_LENGTH_MESSAGE)
       }
     })
     expect(db.query).not.toHaveBeenCalled()
@@ -387,6 +423,51 @@ describe('POST /api/expenses/update', () => {
     })
   })
 
+  it('200 - accepts a description at the merchant length limit during update', async () => {
+    const description = 'M'.repeat(EXPENSE_DESCRIPTION_MAX_LENGTH)
+    db.query
+      .mockResolvedValueOnce({ rows: [{ date: '2026-03-01' }] })
+      .mockResolvedValueOnce({ rows: [{ ...row, description }] })
+    evaluateThresholdForMonth
+      .mockResolvedValueOnce({ alertTriggered: false, budget_alert: null })
+      .mockResolvedValueOnce({ alertTriggered: false, budget_alert: null })
+
+    await testApiHandler({
+      appHandler: updateHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ expense_id: 1, description }))
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenNthCalledWith(
+          2,
+          expect.stringContaining('UPDATE public.expenses SET'),
+          [description, 1, 'uid']
+        )
+      }
+    })
+  })
+
+  it('200 - persists description null when the client clears the merchant on edit', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ date: '2026-03-01' }] })
+      .mockResolvedValueOnce({ rows: [{ ...row, description: null }] })
+    evaluateThresholdForMonth
+      .mockResolvedValueOnce({ alertTriggered: false, budget_alert: null })
+      .mockResolvedValueOnce({ alertTriggered: false, budget_alert: null })
+
+    await testApiHandler({
+      appHandler: updateHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ expense_id: 1, description: null }))
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenNthCalledWith(
+          2,
+          expect.stringContaining('UPDATE public.expenses SET'),
+          [null, 1, 'uid']
+        )
+      }
+    })
+  })
+
   it('400 - missing expense_id', async () => {
     await testApiHandler({
       appHandler: updateHandler,
@@ -430,6 +511,21 @@ describe('POST /api/expenses/update', () => {
         const res = await fetch(post({ expense_id: 1, date: 'bad-date' }))
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('Valid date is required')
+      }
+    })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('400 - rejects an over-limit update description before querying', async () => {
+    await testApiHandler({
+      appHandler: updateHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({
+          expense_id: 1,
+          description: 'M'.repeat(EXPENSE_DESCRIPTION_MAX_LENGTH + 1),
+        }))
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe(EXPENSE_DESCRIPTION_LENGTH_MESSAGE)
       }
     })
     expect(db.query).not.toHaveBeenCalled()

--- a/nextjs/__tests__/frontend/financeUtils.unit.test.js
+++ b/nextjs/__tests__/frontend/financeUtils.unit.test.js
@@ -170,6 +170,8 @@ describe('buildActivityFeed', () => {
     expect(entry.id).toBe('expense-e1')
     expect(entry.amount).toBe(25)
     expect(entry.title).toBe('Coffee')
+    expect(entry.merchant).toBe('Coffee')
+    expect(entry.note).toBe('')
   })
 
   it('uses a compact no-category label for expenses without a category name', () => {
@@ -182,9 +184,17 @@ describe('buildActivityFeed', () => {
     const expenseRow = { id: 'e3', amount: '4.00', date: '2026-03-10', created_at: '2026-03-10T00:00:00Z', description: '', category_name: 'Education' }
     const [entry] = buildActivityFeed([expenseRow], [])
     expect(entry.title).toBe('Education')
-    expect(entry.merchant).toBe('Education')
+    expect(entry.merchant).toBe('')
     expect(entry.note).toBe('')
     expect(Object.values(entry).join(' ')).not.toMatch(/live expense/i)
+  })
+
+  it('keeps the compact expense title fallback separate from a cleared merchant', () => {
+    const expenseRow = { id: 'e4', amount: '18.00', date: '2026-03-10', created_at: '2026-03-10T00:00:00Z', description: null, category_name: 'Dining' }
+    const [entry] = buildActivityFeed([expenseRow], [])
+    expect(entry.title).toBe('Dining')
+    expect(entry.chip).toBe('Dining')
+    expect(entry.merchant).toBe('')
   })
 
   it('sorts combined entries with the most recent first', () => {
@@ -239,6 +249,14 @@ describe('buildActivityFeed', () => {
     const income = [{ id: 'i1', amount: '2000.00', date: '2026-03-20', source_name: 'Payroll' }]
     const [entry] = buildActivityFeed([], income)
     expect(entry.note).toBe('')
+  })
+
+  it('keeps income source as the title and saved notes as the note text', () => {
+    const income = [{ id: 'i2', amount: '100.00', date: '2026-03-21', source_name: 'Freelance', notes: 'Weekend session' }]
+    const [entry] = buildActivityFeed([], income)
+    expect(entry.title).toBe('Freelance')
+    expect(entry.merchant).toBe('Freelance')
+    expect(entry.note).toBe('Weekend session')
   })
 
   it('treats explicit "No source" the same as missing for chip display, but keeps a literal "Income" source name', () => {

--- a/nextjs/__tests__/frontend/transactionDetailSheet.unit.test.js
+++ b/nextjs/__tests__/frontend/transactionDetailSheet.unit.test.js
@@ -67,7 +67,7 @@ describe('TransactionDetailSheet', () => {
       },
     }))
 
-    expect(screen.getByText('Cafe on Main')).toBeTruthy()
+    expect(screen.getAllByText('Cafe on Main')).toHaveLength(2)
   })
 
   it('labels the chip as Category for an expense entry', () => {
@@ -161,7 +161,7 @@ describe('TransactionDetailSheet', () => {
     expect(document.querySelector('.detail-sheet__subtitle').textContent).toBe('Long date 2026-04-15')
   })
 
-  it('displays a distinct body note for expenses when the note is not the category chip', () => {
+  it('displays merchant text for expenses instead of an unsupported note field', () => {
     render(React.createElement(TransactionDetailSheet, {
       onClose: jest.fn(),
       entry: {
@@ -175,11 +175,30 @@ describe('TransactionDetailSheet', () => {
       },
     }))
 
-    const noteCell = screen.getByText('Note').parentElement
-    expect(noteCell.querySelector('strong').textContent).toBe('Gift card for Alex')
+    const merchantCell = screen.getByText('Merchant').parentElement
+    expect(merchantCell.querySelector('strong').textContent).toBe('Store')
+    expect(screen.queryByText('Gift card for Alex')).toBeNull()
   })
 
-  it('shows a neutral income note and plus formatting for income', () => {
+  it('does not use the compact expense title fallback as the merchant value', () => {
+    render(React.createElement(TransactionDetailSheet, {
+      onClose: jest.fn(),
+      entry: {
+        kind: 'expense',
+        title: 'Dining',
+        merchant: '',
+        occurredOn: '2026-01-20',
+        amount: 19.99,
+        chip: 'Dining',
+        note: '',
+      },
+    }))
+
+    const merchantCell = screen.getByText('Merchant').parentElement
+    expect(merchantCell.querySelector('strong').textContent).toBe('No merchant added')
+  })
+
+  it('shows the saved income note even when it matches the source chip', () => {
     render(React.createElement(TransactionDetailSheet, {
       onClose: jest.fn(),
       entry: {
@@ -193,8 +212,29 @@ describe('TransactionDetailSheet', () => {
       },
     }))
 
-    expect(screen.getByText('No note added').closest('strong')).toBeTruthy()
+    const noteCell = screen.getByText('Note').parentElement
+    expect(noteCell.querySelector('strong').textContent).toBe('Salary')
     expect(screen.getByText(/\+.*2500/)).toBeTruthy()
+  })
+
+  it('shows full long income notes in the wide detail field', () => {
+    const longNote = 'N'.repeat(240)
+    render(React.createElement(TransactionDetailSheet, {
+      onClose: jest.fn(),
+      entry: {
+        kind: 'income',
+        title: 'Freelance',
+        merchant: 'Freelance',
+        occurredOn: '2026-03-01',
+        amount: 250,
+        chip: 'Freelance',
+        note: longNote,
+      },
+    }))
+
+    const noteCell = screen.getByText('Note').parentElement
+    expect(noteCell.className).toContain('detail-grid__item--wide')
+    expect(noteCell.querySelector('strong').textContent).toBe(longNote)
   })
 
   it('passes through extra detail content in children', () => {

--- a/nextjs/__tests__/frontend/transactions.test.js
+++ b/nextjs/__tests__/frontend/transactions.test.js
@@ -88,6 +88,12 @@ const { useAuth, useDataMode, useDataChanged } = require('@/components/providers
 const { apiGet, apiPost } = require('@/lib/apiClient')
 const financeUtils = require('@/lib/financeUtils')
 const actualFinanceUtils = jest.requireActual('@/lib/financeUtils')
+const {
+  EXPENSE_DESCRIPTION_LENGTH_MESSAGE,
+  EXPENSE_DESCRIPTION_MAX_LENGTH,
+  INCOME_NOTES_LENGTH_MESSAGE,
+  INCOME_NOTES_MAX_LENGTH,
+} = require('@/lib/transactionText')
 const { default: TransactionsView } = require('@/components/transactions-view')
 
 beforeEach(() => {
@@ -268,6 +274,96 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     const incPost = apiPost.mock.calls.find((c) => c[0] === '/api/income')
     expect(incPost).toBeTruthy()
     expect(incPost[1].source_id).toBeUndefined()
+  })
+
+  it('hides expense notes and validates over-limit merchant text before posting', async () => {
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
+    const dialog = screen.getByRole('dialog')
+    expect(within(dialog).queryByLabelText('Note')).toBeNull()
+
+    act(() => {
+      fireEvent.change(within(dialog).getByLabelText('Merchant'), {
+        target: { value: 'M'.repeat(EXPENSE_DESCRIPTION_MAX_LENGTH + 1) },
+      })
+    })
+
+    expect(screen.getByRole('alert').textContent).toBe(EXPENSE_DESCRIPTION_LENGTH_MESSAGE)
+    expect(within(dialog).getByRole('button', { name: 'Add transaction' }).disabled).toBe(true)
+    expect(apiPost).not.toHaveBeenCalled()
+  })
+
+  it('uses Note as the only income free-text field and posts it as notes', async () => {
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
+    const dialog = screen.getByRole('dialog')
+    act(() => { fireEvent.click(within(dialog).getByRole('button', { name: 'Income' })) })
+
+    expect(within(dialog).queryByLabelText('Merchant')).toBeNull()
+    expect(within(dialog).getByLabelText('Note')).toBeTruthy()
+    act(() => { fireEvent.change(dialog.querySelector('input.input-field[inputmode="decimal"]'), { target: { value: '100' } }) })
+    act(() => { fireEvent.change(within(dialog).getByLabelText('Note'), { target: { value: 'Weekend session' } }) })
+    act(() => { fireEvent.click(within(dialog).getByRole('button', { name: 'Add transaction' })) })
+
+    await waitFor(() => {
+      const incPost = apiPost.mock.calls.find((c) => c[0] === '/api/income')
+      expect(incPost[1].notes).toBe('Weekend session')
+    })
+  })
+
+  it('validates over-limit income notes before posting', async () => {
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
+    const dialog = screen.getByRole('dialog')
+    act(() => { fireEvent.click(within(dialog).getByRole('button', { name: 'Income' })) })
+    act(() => {
+      fireEvent.change(within(dialog).getByLabelText('Note'), {
+        target: { value: 'N'.repeat(INCOME_NOTES_MAX_LENGTH + 1) },
+      })
+    })
+
+    expect(screen.getByRole('alert').textContent).toBe(INCOME_NOTES_LENGTH_MESSAGE)
+    expect(within(dialog).getByRole('button', { name: 'Add transaction' }).disabled).toBe(true)
+    expect(apiPost).not.toHaveBeenCalled()
+  })
+
+  it('renders long live transaction text in constrained list elements', async () => {
+    financeUtils.buildActivityFeed.mockImplementation((expenses, income) =>
+      actualFinanceUtils.buildActivityFeed(expenses, income))
+    const longMerchant = 'M'.repeat(EXPENSE_DESCRIPTION_MAX_LENGTH + 20)
+    const longNote = 'N'.repeat(INCOME_NOTES_MAX_LENGTH)
+    apiGet.mockImplementation((url) => {
+      if (url === '/api/expenses') {
+        return Promise.resolve([{
+          id: 70,
+          amount: '8.00',
+          date: '2026-03-12',
+          description: longMerchant,
+          category_name: 'Food',
+        }])
+      }
+      if (url === '/api/income') {
+        return Promise.resolve([{
+          id: 91,
+          amount: '200.00',
+          date: '2026-03-11',
+          notes: longNote,
+          source_name: 'Freelance',
+        }])
+      }
+      if (url === '/api/expenses/categories') return Promise.resolve([])
+      if (url === '/api/income/categories') return Promise.resolve([])
+      return Promise.resolve([])
+    })
+
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+
+    expect(document.querySelector('.transaction-item__title').textContent).toBe(longMerchant)
+    expect(document.querySelector('.transaction-item__note').textContent).toBe(longNote)
   })
 
   it('sends category_id: null on update when editing an expense and clearing the category', async () => {

--- a/nextjs/__tests__/frontend/transactions.test.js
+++ b/nextjs/__tests__/frontend/transactions.test.js
@@ -249,6 +249,43 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     expect(expensePost[1].category_id).toBe('c-edu')
   })
 
+  it('prevents negative and over-precision expense amount drafts while accepting cents-only values', async () => {
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
+    const dialog = screen.getByRole('dialog')
+    const amountInput = dialog.querySelector('input.input-field[inputmode="decimal"]')
+
+    act(() => { fireEvent.change(amountInput, { target: { value: '-5' } }) })
+    expect(amountInput.value).toBe('')
+
+    act(() => { fireEvent.change(amountInput, { target: { value: '12.345' } }) })
+    expect(amountInput.value).toBe('')
+
+    act(() => { fireEvent.change(amountInput, { target: { value: '.25' } }) })
+    expect(amountInput.value).toBe('.25')
+    act(() => { fireEvent.click(within(dialog).getByRole('button', { name: 'Add transaction' })) })
+
+    await waitFor(() => {
+      const expensePost = apiPost.mock.calls.find((c) => c[0] === '/api/expenses')
+      expect(expensePost[1].amount).toBe(0.25)
+    })
+  })
+
+  it('blocks trailing decimal amount drafts before creating an expense', async () => {
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Add transaction' })) })
+    const dialog = screen.getByRole('dialog')
+    const amountInput = dialog.querySelector('input.input-field[inputmode="decimal"]')
+
+    act(() => { fireEvent.change(amountInput, { target: { value: '12.' } }) })
+
+    expect(screen.getByRole('alert').textContent).toBe('Enter a valid amount with up to 2 decimal places.')
+    expect(within(dialog).getByRole('button', { name: 'Add transaction' }).disabled).toBe(true)
+    expect(apiPost).not.toHaveBeenCalled()
+  })
+
   it('switches to income with the first source pre-selected', async () => {
     render(React.createElement(TransactionsView))
     await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
@@ -272,6 +309,39 @@ describe('TransactionsView (live) entry form (Issue #58)', () => {
     const incPost = apiPost.mock.calls.find((c) => c[0] === '/api/income')
     expect(incPost).toBeTruthy()
     expect(incPost[1].source_id).toBe('i-bus')
+  })
+
+  it('blocks trailing decimal amount drafts before updating income', async () => {
+    financeUtils.buildActivityFeed.mockImplementation((expenses, income) =>
+      actualFinanceUtils.buildActivityFeed(expenses, income))
+    apiGet.mockImplementation((url) => {
+      if (url === '/api/expenses') return Promise.resolve([])
+      if (url === '/api/income') {
+        return Promise.resolve([{
+          id: 92,
+          amount: '200.00',
+          date: '2026-03-05',
+          notes: 'Pay',
+          source_name: 'Freelance',
+          source_id: 'src-f',
+        }])
+      }
+      if (url === '/api/expenses/categories') return Promise.resolve([])
+      if (url === '/api/income/categories') return Promise.resolve([{ id: 'src-f', name: 'Freelance', icon: null }])
+      return Promise.resolve([])
+    })
+    render(React.createElement(TransactionsView))
+    await waitFor(() => { expect(screen.queryByText('Loading activity')).toBeNull() })
+    act(() => { fireEvent.click(screen.getAllByText('Freelance')[0]) })
+    act(() => { fireEvent.click(screen.getByRole('button', { name: 'Edit' })) })
+    const formDialog = screen.getByRole('dialog')
+    const amountInput = formDialog.querySelector('input.input-field[inputmode="decimal"]')
+
+    act(() => { fireEvent.change(amountInput, { target: { value: '200.' } }) })
+
+    expect(screen.getByRole('alert').textContent).toBe('Enter a valid amount with up to 2 decimal places.')
+    expect(within(formDialog).getByRole('button', { name: 'Save changes' }).disabled).toBe(true)
+    expect(apiPost).not.toHaveBeenCalled()
   })
 
   it('hides expense notes and validates over-limit merchant text before posting', async () => {

--- a/nextjs/__tests__/income.test.js
+++ b/nextjs/__tests__/income.test.js
@@ -20,6 +20,10 @@ const categoriesHandler = require('@/app/api/income/categories/route')
 const getHandler = require('@/app/api/income/get/route')
 const updateHandler = require('@/app/api/income/update/route')
 const deleteHandler = require('@/app/api/income/delete/route')
+const {
+  INCOME_NOTES_LENGTH_MESSAGE,
+  INCOME_NOTES_MAX_LENGTH,
+} = require('@/lib/transactionText')
 
 const post = (body) => ({ method: 'POST', body: JSON.stringify(body), headers: { 'content-type': 'application/json' } })
 
@@ -61,6 +65,22 @@ describe('POST /api/income', () => {
         expect(db.query).toHaveBeenCalledWith(
           expect.stringContaining('INSERT INTO public.income'),
           ['uid', null, 3000, '2026-03-15', null]
+        )
+      }
+    })
+  })
+
+  it('accepts notes at the length limit', async () => {
+    const notes = 'N'.repeat(INCOME_NOTES_MAX_LENGTH)
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, notes }] })
+    await testApiHandler({
+      appHandler: incomeHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ amount: 3000, date: '2026-03-15', notes }))
+        expect(res.status).toBe(201)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('INSERT INTO public.income'),
+          ['uid', null, 3000, '2026-03-15', notes]
         )
       }
     })
@@ -119,6 +139,22 @@ describe('POST /api/income', () => {
         const res = await fetch(post({ amount: '0.001', date: '2026-03-15' }))
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('amount must be a valid positive money amount')
+      }
+    })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects over-limit notes before querying', async () => {
+    await testApiHandler({
+      appHandler: incomeHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({
+          amount: 3000,
+          date: '2026-03-15',
+          notes: 'N'.repeat(INCOME_NOTES_MAX_LENGTH + 1),
+        }))
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe(INCOME_NOTES_LENGTH_MESSAGE)
       }
     })
     expect(db.query).not.toHaveBeenCalled()
@@ -383,6 +419,37 @@ describe('POST /api/income/update', () => {
     })
   })
 
+  it('accepts notes at the length limit during update', async () => {
+    const notes = 'N'.repeat(INCOME_NOTES_MAX_LENGTH)
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, notes }] })
+    await testApiHandler({
+      appHandler: updateHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ income_id: 1, notes }))
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('UPDATE public.income SET'),
+          [notes, 1, 'uid']
+        )
+      }
+    })
+  })
+
+  it('persists notes null when the client clears the note on edit', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ ...row, notes: null }] })
+    await testApiHandler({
+      appHandler: updateHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({ income_id: 1, notes: null }))
+        expect(res.status).toBe(200)
+        expect(db.query).toHaveBeenCalledWith(
+          expect.stringContaining('UPDATE public.income SET'),
+          [null, 1, 'uid']
+        )
+      }
+    })
+  })
+
   it('rejects update without income_id', async () => {
     await testApiHandler({
       appHandler: updateHandler,
@@ -436,6 +503,21 @@ describe('POST /api/income/update', () => {
         const res = await fetch(post({ income_id: 1, amount: '1.999' }))
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('amount must be a valid positive money amount')
+      }
+    })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('rejects over-limit update notes before querying', async () => {
+    await testApiHandler({
+      appHandler: updateHandler,
+      async test({ fetch }) {
+        const res = await fetch(post({
+          income_id: 1,
+          notes: 'N'.repeat(INCOME_NOTES_MAX_LENGTH + 1),
+        }))
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe(INCOME_NOTES_LENGTH_MESSAGE)
       }
     })
     expect(db.query).not.toHaveBeenCalled()

--- a/nextjs/src/app/api/expenses/route.js
+++ b/nextjs/src/app/api/expenses/route.js
@@ -3,6 +3,7 @@ import db from '@/lib/db'
 import { authenticate } from '@/lib/auth'
 import { evaluateThresholdForMonth, isPositiveMoneyValue, normalizeDate } from '@/lib/budget'
 import { buildTransactionListQuery } from '@/lib/transactionQuery'
+import { validateExpenseDescription } from '@/lib/transactionText'
 
 export async function GET(request) {
   const { user, error } = await authenticate(request)
@@ -47,11 +48,15 @@ export async function POST(request) {
   if (!normalizedDate) {
     return NextResponse.json({ error: 'Valid date is required' }, { status: 400 })
   }
+  const descriptionValidation = validateExpenseDescription(description)
+  if (descriptionValidation.error) {
+    return NextResponse.json({ error: descriptionValidation.error }, { status: 400 })
+  }
   try {
     const { rows } = await db.query(
       `INSERT INTO public.expenses (user_id, category_id, amount, description, date)
        VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-      [user.id, category_id ?? null, amount, description ?? null, normalizedDate]
+      [user.id, category_id ?? null, amount, descriptionValidation.value ?? null, normalizedDate]
     )
     const { user_id, ...expense } = rows[0]
     const threshold = await evaluateThresholdForMonth(user.id, expense.date)

--- a/nextjs/src/app/api/expenses/update/route.js
+++ b/nextjs/src/app/api/expenses/update/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import db from '@/lib/db'
 import { authenticate } from '@/lib/auth'
 import { evaluateThresholdForMonth, isPositiveMoneyValue, normalizeDate } from '@/lib/budget'
+import { validateExpenseDescription } from '@/lib/transactionText'
 
 export async function POST(request) {
   const { user, error } = await authenticate(request)
@@ -21,10 +22,15 @@ export async function POST(request) {
     return NextResponse.json({ error: 'Valid date is required' }, { status: 400 })
   }
 
+  const descriptionValidation = validateExpenseDescription(description)
+  if (descriptionValidation.error) {
+    return NextResponse.json({ error: descriptionValidation.error }, { status: 400 })
+  }
+
   const entries = Object.entries({
     category_id,
     amount,
-    description,
+    description: descriptionValidation.value,
     date: normalizedDate
   }).filter(([, v]) => v !== undefined)
   if (!entries.length) return NextResponse.json({ error: 'No fields provided to update' }, { status: 400 })

--- a/nextjs/src/app/api/income/route.js
+++ b/nextjs/src/app/api/income/route.js
@@ -3,6 +3,7 @@ import db from '@/lib/db'
 import { authenticate } from '@/lib/auth'
 import { isPositiveMoneyValue, normalizeDate } from '@/lib/budget'
 import { buildTransactionListQuery } from '@/lib/transactionQuery'
+import { validateIncomeNotes } from '@/lib/transactionText'
 
 export async function GET(request) {
   const { user, error } = await authenticate(request)
@@ -43,11 +44,15 @@ export async function POST(request) {
   }
   const normalizedDate = normalizeDate(date)
   if (!normalizedDate) return NextResponse.json({ error: 'Valid date is required' }, { status: 400 })
+  const notesValidation = validateIncomeNotes(notes)
+  if (notesValidation.error) {
+    return NextResponse.json({ error: notesValidation.error }, { status: 400 })
+  }
   try {
     const { rows } = await db.query(
       `INSERT INTO public.income (user_id, source_id, amount, date, notes)
        VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-      [user.id, source_id ?? null, amount, normalizedDate, notes ?? null]
+      [user.id, source_id ?? null, amount, normalizedDate, notesValidation.value ?? null]
     )
     const { user_id, ...income } = rows[0]
     return NextResponse.json(income, { status: 201 })

--- a/nextjs/src/app/api/income/update/route.js
+++ b/nextjs/src/app/api/income/update/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import db from '@/lib/db'
 import { authenticate } from '@/lib/auth'
 import { isPositiveMoneyValue, normalizeDate } from '@/lib/budget'
+import { validateIncomeNotes } from '@/lib/transactionText'
 
 export async function POST(request) {
   const { user, error } = await authenticate(request)
@@ -21,11 +22,16 @@ export async function POST(request) {
     return NextResponse.json({ error: 'Valid date is required' }, { status: 400 })
   }
 
+  const notesValidation = validateIncomeNotes(notes)
+  if (notesValidation.error) {
+    return NextResponse.json({ error: notesValidation.error }, { status: 400 })
+  }
+
   const entries = Object.entries({
     source_id,
     amount,
     date: normalizedDate,
-    notes
+    notes: notesValidation.value
   }).filter(([, v]) => v !== undefined)
   if (!entries.length) return NextResponse.json({ error: 'No fields provided to update' }, { status: 400 })
 

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -3119,12 +3119,33 @@ button.activity-feed__row:focus-visible {
   flex: 1;
 }
 
+.transaction-item__body {
+  overflow: hidden;
+}
+
+.transaction-item__title {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .entry-meta,
 .transaction-item__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem 0.55rem;
   align-items: center;
+}
+
+.transaction-item__note {
+  min-width: 0;
+  display: -webkit-box;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .entry-chip {
@@ -3341,6 +3362,11 @@ html[data-theme='dark'] .search-field__input {
   margin: 0.35rem 0 0.15rem;
   font-size: 1.45rem;
   letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
+}
+
+.detail-sheet__subtitle {
+  overflow-wrap: anywhere;
 }
 
 .detail-sheet__amount {
@@ -3377,6 +3403,11 @@ html[data-theme='dark'] .detail-grid div {
   display: block;
   font-size: 0.95rem;
   line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.detail-grid__item--wide {
+  grid-column: 1 / -1;
 }
 
 .insight-stage {
@@ -5495,6 +5526,7 @@ html[data-theme='dark'] .transactions-fab {
 .entry-sheet__amount small,
 .entry-sheet__hint {
   color: var(--text-secondary);
+  overflow-wrap: anywhere;
 }
 
 .entry-sheet__segment {
@@ -11631,4 +11663,3 @@ html[data-theme='dark'] .category-modal__row {
   color: var(--text-secondary);
   line-height: 1.5;
 }
-

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -149,6 +149,9 @@ const EXTRA_SAMPLE_ACTIVITY = [
 const SAMPLE_ACTIVITY = [...demoActivity, ...EXTRA_SAMPLE_ACTIVITY]
   .sort((left, right) => right.occurredOn.localeCompare(left.occurredOn) || right.id.localeCompare(left.id))
 
+const MONEY_DRAFT_PATTERN = /^\d*(?:\.\d{0,2})?$/
+const MONEY_SUBMIT_PATTERN = /^(?:\d+(?:\.\d{1,2})?|\.\d{1,2})$/
+
 function getTodayInputValue(date = new Date()) {
   const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
   return localDate.toISOString().slice(0, 10)
@@ -188,6 +191,20 @@ function getErrorMessage(error) {
   if (error instanceof ApiError) return error.message
   if (error instanceof Error && error.message) return error.message
   return 'The live transaction feed is not available right now.'
+}
+
+function isValidMoneyDraft(value) {
+  return value === '' || MONEY_DRAFT_PATTERN.test(value)
+}
+
+function validateMoneyAmount(value) {
+  const trimmedValue = value.trim()
+  if (!MONEY_SUBMIT_PATTERN.test(trimmedValue)) return 'Enter a valid amount with up to 2 decimal places.'
+
+  const amount = Number(trimmedValue)
+  if (!Number.isFinite(amount) || amount <= 0) return 'Enter a valid amount greater than $0.00.'
+
+  return ''
 }
 
 function LiveNotice({ message, onRetry }) {
@@ -418,7 +435,8 @@ export default function TransactionsView() {
     ? validateExpenseDescription(entryDraft.counterparty)
     : validateIncomeNotes(entryDraft.note)
   const draftTextError = draftTextValidation.error || ''
-  const footerError = saveError || draftTextError
+  const draftAmountError = entryDraft.amount ? validateMoneyAmount(entryDraft.amount) : ''
+  const footerError = saveError || draftTextError || draftAmountError
 
   const updateDraft = (field, value) => {
     setSaveError('')
@@ -426,6 +444,11 @@ export default function TransactionsView() {
       ...current,
       [field]: value,
     }))
+  }
+
+  const updateAmountDraft = (value) => {
+    if (!isValidMoneyDraft(value)) return
+    updateDraft('amount', value)
   }
 
   const openEntrySheet = (entryToEdit = null) => {
@@ -451,6 +474,11 @@ export default function TransactionsView() {
     if (isSaving) return
     if (draftTextError) {
       setSaveError(draftTextError)
+      return
+    }
+    const amountError = validateMoneyAmount(entryDraft.amount)
+    if (amountError) {
+      setSaveError(amountError)
       return
     }
     setIsSaving(true)
@@ -800,9 +828,9 @@ export default function TransactionsView() {
                   <input
                     className="input-field"
                     inputMode="decimal"
-                    onChange={(event) => updateDraft('amount', event.target.value)}
+                    onChange={(event) => updateAmountDraft(event.target.value)}
                     placeholder="0.00"
-                    type="number"
+                    type="text"
                     value={entryDraft.amount}
                   />
                 </label>
@@ -891,6 +919,7 @@ export default function TransactionsView() {
                       !entryDraft.amount ||
                       !entryDraft.occurredOn ||
                       Boolean(draftTextError) ||
+                      Boolean(draftAmountError) ||
                       (!editingEntry && (!entryDraft.category ||
                         !(entryDraft.kind === 'expense' ? expenseCategories : incomeCategories).some(
                            (category) => category.name === entryDraft.category

--- a/nextjs/src/components/transactions-view.js
+++ b/nextjs/src/components/transactions-view.js
@@ -15,6 +15,7 @@ import {
   groupActivityByDate,
   resolveCategoryOrSourceMutation,
 } from '@/lib/financeUtils'
+import { validateExpenseDescription, validateIncomeNotes } from '@/lib/transactionText'
 import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const ENTRY_CATEGORY_OPTIONS = {
@@ -178,8 +179,8 @@ function createEditDraft(entry) {
   }
   return {
     ...base,
-    counterparty: entry.raw?.notes || '',
     note: entry.raw?.notes || '',
+    counterparty: '',
   }
 }
 
@@ -372,10 +373,11 @@ export default function TransactionsView() {
     if (!searchQuery.trim()) return true
 
     const query = searchQuery.toLowerCase()
+    const searchableNote = entry.kind === 'income' ? entry.note : ''
     return (
       entry.title.toLowerCase().includes(query) ||
       entry.chip.toLowerCase().includes(query) ||
-      entry.note.toLowerCase().includes(query) ||
+      searchableNote.toLowerCase().includes(query) ||
       entry.merchant.toLowerCase().includes(query)
     )
   })
@@ -391,15 +393,22 @@ export default function TransactionsView() {
   })
   const entryAmountValue = Number(entryDraft.amount)
   const entryAmountLabel = entryDraft.amount ? formatCurrency(Math.abs(entryAmountValue || 0)) : '$0.00'
-  const entryTitle = entryDraft.counterparty.trim() || (entryDraft.kind === 'income' ? 'New income' : 'New expense')
-  const counterpartyLabel = entryDraft.kind === 'income' ? 'Description' : 'Merchant'
+  const entryTitle = entryDraft.kind === 'income'
+    ? entryDraft.note.trim() || entryDraft.category || 'New income'
+    : entryDraft.counterparty.trim() || 'New expense'
   const categoryFieldLabel = entryDraft.kind === 'income' ? 'Source' : 'Category'
   const entryCategories = entryDraft.kind === 'expense'
     ? (expenseCategories.length ? expenseCategories : ENTRY_CATEGORY_OPTIONS.expense.map((n) => ({ name: n, icon: null })))
     : (incomeCategories.length ? incomeCategories : ENTRY_CATEGORY_OPTIONS.income.map((n) => ({ name: n, icon: null })))
   const hideFab = Boolean(selectedEntry) || isEntrySheetOpen
+  const draftTextValidation = entryDraft.kind === 'expense'
+    ? validateExpenseDescription(entryDraft.counterparty)
+    : validateIncomeNotes(entryDraft.note)
+  const draftTextError = draftTextValidation.error || ''
+  const footerError = saveError || draftTextError
 
   const updateDraft = (field, value) => {
+    setSaveError('')
     setEntryDraft((current) => ({
       ...current,
       [field]: value,
@@ -422,13 +431,18 @@ export default function TransactionsView() {
 
   const handleSaveEntry = async () => {
     if (isSaving) return
+    if (draftTextError) {
+      setSaveError(draftTextError)
+      return
+    }
     setIsSaving(true)
     setSaveError('')
     try {
       if (entryDraft.kind === 'expense') {
+        const description = validateExpenseDescription(entryDraft.counterparty).value
         const body = {
           amount: Number(entryDraft.amount),
-          description: entryDraft.counterparty.trim() || undefined,
+          description: editingEntry ? description ?? null : description ?? undefined,
           date: entryDraft.occurredOn,
           ...resolveCategoryOrSourceMutation({
             isEdit: Boolean(editingEntry),
@@ -443,10 +457,11 @@ export default function TransactionsView() {
           await apiPost('/api/expenses', body, { accessToken: session.accessToken })
         }
       } else {
+        const notes = validateIncomeNotes(entryDraft.note).value
         const body = {
           amount: Number(entryDraft.amount),
           date: entryDraft.occurredOn,
-          notes: (entryDraft.note.trim() || entryDraft.counterparty.trim()) || undefined,
+          notes: editingEntry ? notes ?? null : notes ?? undefined,
           ...resolveCategoryOrSourceMutation({
             isEdit: Boolean(editingEntry),
             selectedName: entryDraft.category,
@@ -586,10 +601,10 @@ export default function TransactionsView() {
                         </div>
 
                         <div className="transaction-item__body">
-                          <strong>{entry.merchant || entry.title}</strong>
+                          <strong className="transaction-item__title">{entry.merchant || entry.title}</strong>
                           <div className="transaction-item__meta">
                             <span className="entry-chip">{entry.chip}</span>
-                            {entry.note && entry.note !== entry.chip ? <span>{entry.note}</span> : null}
+                            {entry.kind === 'income' && entry.note ? <span className="transaction-item__note">{entry.note}</span> : null}
                           </div>
                         </div>
 
@@ -728,11 +743,15 @@ export default function TransactionsView() {
               <button
                 className={`segment-control__button${entryDraft.kind === 'expense' ? ' segment-control__button--active' : ''}`}
                 disabled={!!editingEntry}
-                onClick={() => setEntryDraft((current) => ({
-                  ...current,
-                  kind: 'expense',
-                  category: '',
-                }))}
+                onClick={() => {
+                  setSaveError('')
+                  setEntryDraft((current) => ({
+                    ...current,
+                    kind: 'expense',
+                    category: '',
+                    note: '',
+                  }))
+                }}
                 type="button"
               >
                 Expense
@@ -740,11 +759,15 @@ export default function TransactionsView() {
               <button
                 className={`segment-control__button${entryDraft.kind === 'income' ? ' segment-control__button--active' : ''}`}
                 disabled={!!editingEntry}
-                onClick={() => setEntryDraft((current) => ({
-                  ...current,
-                  kind: 'income',
-                  category: '',
-                }))}
+                onClick={() => {
+                  setSaveError('')
+                  setEntryDraft((current) => ({
+                    ...current,
+                    kind: 'income',
+                    category: '',
+                    counterparty: '',
+                  }))
+                }}
                 type="button"
               >
                 Income
@@ -765,16 +788,19 @@ export default function TransactionsView() {
                   />
                 </label>
 
-                <label className="entry-sheet__field">
-                  <span>{counterpartyLabel}</span>
-                  <input
-                    className="input-field"
-                    onChange={(event) => updateDraft('counterparty', event.target.value)}
-                    placeholder={entryDraft.kind === 'income' ? 'Payroll, transfer, refund...' : 'Target, Uber, rent...'}
-                    type="text"
-                    value={entryDraft.counterparty}
-                  />
-                </label>
+                {entryDraft.kind === 'expense' ? (
+                  <label className="entry-sheet__field">
+                    <span>Merchant</span>
+                    <input
+                      className="input-field"
+                      aria-invalid={draftTextError ? 'true' : undefined}
+                      onChange={(event) => updateDraft('counterparty', event.target.value)}
+                      placeholder="Target, Uber, rent..."
+                      type="text"
+                      value={entryDraft.counterparty}
+                    />
+                  </label>
+                ) : null}
               </div>
 
               <div className="entry-sheet__grid entry-sheet__grid--secondary">
@@ -807,20 +833,23 @@ export default function TransactionsView() {
                 </label>
               </div>
 
-              <label className="entry-sheet__field">
-                <span>Note</span>
-                <textarea
-                  className="input-field entry-sheet__textarea"
-                  onChange={(event) => updateDraft('note', event.target.value)}
-                  placeholder="Add context for the transaction"
-                  rows="3"
-                  value={entryDraft.note}
-                />
-              </label>
+              {entryDraft.kind === 'income' ? (
+                <label className="entry-sheet__field">
+                  <span>Note</span>
+                  <textarea
+                    className="input-field entry-sheet__textarea"
+                    aria-invalid={draftTextError ? 'true' : undefined}
+                    onChange={(event) => updateDraft('note', event.target.value)}
+                    placeholder="Add context for the transaction"
+                    rows="3"
+                    value={entryDraft.note}
+                  />
+                </label>
+              ) : null}
 
               <div className="entry-sheet__footer">
-                {saveError ? (
-                  <div className="inline-error" role="alert">{saveError}</div>
+                {footerError ? (
+                  <div className="inline-error" role="alert">{footerError}</div>
                 ) : (
                   <span className="entry-sheet__hint">
                     {isSampleMode
@@ -836,7 +865,7 @@ export default function TransactionsView() {
                   </button>
                   <button
                     className="button-primary"
-                    disabled={isSaving || isSampleMode || !entryDraft.amount || !entryDraft.occurredOn}
+                    disabled={isSaving || isSampleMode || !entryDraft.amount || !entryDraft.occurredOn || Boolean(draftTextError)}
                     type="submit"
                   >
                     {isSaving ? 'Saving...' : editingEntry ? 'Save changes' : 'Add transaction'}

--- a/nextjs/src/components/ui/TransactionDetailSheet.js
+++ b/nextjs/src/components/ui/TransactionDetailSheet.js
@@ -8,14 +8,15 @@ export default function TransactionDetailSheet({ entry, onClose, children }) {
 
   const visual = getEntryVisual(entry)
   const displayTitle = entry.title || visual.label || (entry.kind === 'income' ? 'Income' : 'Expense')
-  const selectedNote = entry.note && entry.note !== entry.chip
-    ? entry.note
-    : 'No note added'
+  const detailTextLabel = entry.kind === 'income' ? 'Note' : 'Merchant'
+  const detailTextValue = entry.kind === 'income'
+    ? entry.note?.trim() || 'No note added'
+    : entry.merchant?.trim() || 'No merchant added'
 
-  const selectedSubtitle = entry.merchant && entry.merchant !== displayTitle
-    ? entry.merchant
-    : entry.note && entry.note !== entry.chip
-      ? entry.note
+  const selectedSubtitle = entry.kind === 'income' && entry.note?.trim()
+    ? entry.note.trim()
+    : entry.merchant && entry.merchant !== displayTitle
+      ? entry.merchant
       : formatLongDate(entry.occurredOn)
   const categoryOrSourceLabel = entry.kind === 'income' ? 'Source' : 'Category'
 
@@ -69,9 +70,9 @@ export default function TransactionDetailSheet({ entry, onClose, children }) {
             <span>Type</span>
             <strong>{entry.kind === 'income' ? 'Income' : 'Expense'}</strong>
           </div>
-          <div>
-            <span>Note</span>
-            <strong>{selectedNote}</strong>
+          <div className="detail-grid__item--wide">
+            <span>{detailTextLabel}</span>
+            <strong>{detailTextValue}</strong>
           </div>
         </div>
 

--- a/nextjs/src/lib/financeUtils.js
+++ b/nextjs/src/lib/financeUtils.js
@@ -256,8 +256,8 @@ export function buildActivityFeed(expenses = [], income = []) {
       amount: Number(expense.amount ?? 0),
       occurredOn: expense.date || expense.created_at,
       sortOn: parseCalendarDate(expense.date || expense.created_at)?.getTime() ?? 0,
-      note: description ? displayCategory : '',
-      merchant: description || displayCategory,
+      note: '',
+      merchant: description || '',
       raw: expense,
     }
   })
@@ -270,7 +270,7 @@ export function buildActivityFeed(expenses = [], income = []) {
     return {
       id: `income-${entry.id}`,
       kind: 'income',
-      title: notes || sourceName || displayCategory,
+      title: sourceName || displayCategory,
       chip: displayCategory,
       sourceIcon: entry.source_icon ?? null,
       amount: Number(entry.amount ?? 0),

--- a/nextjs/src/lib/transactionText.js
+++ b/nextjs/src/lib/transactionText.js
@@ -1,0 +1,35 @@
+export const EXPENSE_DESCRIPTION_MAX_LENGTH = 80
+export const INCOME_NOTES_MAX_LENGTH = 240
+
+export const EXPENSE_DESCRIPTION_LENGTH_MESSAGE = 'Merchant must be 80 characters or fewer.'
+export const INCOME_NOTES_LENGTH_MESSAGE = 'Note must be 240 characters or fewer.'
+
+const EXPENSE_DESCRIPTION_TYPE_MESSAGE = 'Merchant must be text.'
+const INCOME_NOTES_TYPE_MESSAGE = 'Note must be text.'
+
+function validateOptionalText(value, { maxLength, lengthMessage, typeMessage }) {
+  if (value === undefined) return { value: undefined }
+  if (value === null) return { value: null }
+  if (typeof value !== 'string') return { error: typeMessage }
+
+  const trimmed = value.trim()
+  if (!trimmed) return { value: null }
+  if (trimmed.length > maxLength) return { error: lengthMessage }
+  return { value: trimmed }
+}
+
+export function validateExpenseDescription(value) {
+  return validateOptionalText(value, {
+    maxLength: EXPENSE_DESCRIPTION_MAX_LENGTH,
+    lengthMessage: EXPENSE_DESCRIPTION_LENGTH_MESSAGE,
+    typeMessage: EXPENSE_DESCRIPTION_TYPE_MESSAGE,
+  })
+}
+
+export function validateIncomeNotes(value) {
+  return validateOptionalText(value, {
+    maxLength: INCOME_NOTES_MAX_LENGTH,
+    lengthMessage: INCOME_NOTES_LENGTH_MESSAGE,
+    typeMessage: INCOME_NOTES_TYPE_MESSAGE,
+  })
+}


### PR DESCRIPTION
## Description
Constrain transaction free-text handling for expenses and income.

This PR adds shared validation for expense merchants and income notes, enforcing 80-character merchant text and 240-character income notes on both create and update API routes. It also updates the Transactions UI so expenses use a Merchant field, income uses a Note field, long transaction text stays visually constrained, and the detail sheet displays merchant/note content clearly without mixing fallback labels into saved text.

## Related User Story / Issue
Fixes #98

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [x] Refactor

## How Has This Been Tested?
- [ ] GitHub Actions / CI tests passed
- [ ] Manual testing performed
- [X] Not tested locally

### Test Notes
- `npx jest --runTestsByPath __tests__/expenses.test.js __tests__/income.test.js __tests__/frontend/financeUtils.unit.test.js __tests__/frontend/transactionDetailSheet.unit.test.js __tests__/frontend/transactions.test.js`
- `npx jest --runInBand --coverage=false`
- `npm run build`

Manual browser QA still needs to be completed.

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Notes for Reviewers
The shared transaction text validator trims whitespace, normalizes empty text to `null`, and rejects non-string or over-limit values before database writes. Expense descriptions now represent merchant text only; income notes remain the free-text note field. The activity feed and detail sheet were updated to avoid showing fallback category/source labels as saved merchant or note text.

## Checklist
- [x] Linked to a user story or issue
- [ ] Code builds / tests pass in CI
- [x] Ready for review
