### PR TITLE
Allow clearing category plans

### DIFF
--- a/nextjs/__tests__/apiClient.test.js
+++ b/nextjs/__tests__/apiClient.test.js
@@ -1,4 +1,4 @@
-const { ApiError, apiGet } = require('@/lib/apiClient')
+const { ApiError, apiDelete, apiGet } = require('@/lib/apiClient')
 
 describe('apiGet', () => {
   const originalFetch = global.fetch
@@ -68,5 +68,29 @@ describe('apiGet', () => {
 
     expect(error.status).toBe(418)
     expect(error.body).toEqual({ error: 'Boom' })
+  })
+
+  it('sends authenticated DELETE requests and returns parsed json', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValueOnce({ cleared: true }),
+    })
+
+    await expect(apiDelete('/api/test?item=1', { accessToken: 'token-123' })).resolves.toEqual({ cleared: true })
+    expect(global.fetch).toHaveBeenCalledWith('/api/test?item=1', expect.objectContaining({
+      method: 'DELETE',
+      cache: 'no-store',
+      headers: {
+        authorization: 'Bearer token-123',
+      },
+    }))
+  })
+
+  it('throws a 401 ApiError when deleting without an access token', async () => {
+    await expect(apiDelete('/api/test')).rejects.toEqual(expect.objectContaining({
+      name: 'ApiError',
+      status: 401,
+      message: 'Missing access token',
+    }))
   })
 })

--- a/nextjs/__tests__/apiClient.test.js
+++ b/nextjs/__tests__/apiClient.test.js
@@ -1,16 +1,16 @@
 const { ApiError, apiDelete, apiGet } = require('@/lib/apiClient')
 
+const originalFetch = global.fetch
+
+beforeEach(() => {
+  global.fetch = jest.fn()
+})
+
+afterAll(() => {
+  global.fetch = originalFetch
+})
+
 describe('apiGet', () => {
-  const originalFetch = global.fetch
-
-  beforeEach(() => {
-    global.fetch = jest.fn()
-  })
-
-  afterAll(() => {
-    global.fetch = originalFetch
-  })
-
   it('attaches the bearer token and returns parsed json', async () => {
     global.fetch.mockResolvedValueOnce({
       ok: true,
@@ -69,7 +69,9 @@ describe('apiGet', () => {
     expect(error.status).toBe(418)
     expect(error.body).toEqual({ error: 'Boom' })
   })
+})
 
+describe('apiDelete', () => {
   it('sends authenticated DELETE requests and returns parsed json', async () => {
     global.fetch.mockResolvedValueOnce({
       ok: true,

--- a/nextjs/__tests__/budget.test.js
+++ b/nextjs/__tests__/budget.test.js
@@ -9,6 +9,7 @@ jest.mock('@/lib/budget', () => {
     getMonthlyBudget: jest.fn(),
     getMonthlyBudgetConfig: jest.fn(),
     getOwnedOrGlobalCategoriesByIds: jest.fn(),
+    deleteCategoryBudget: jest.fn(),
     upsertMonthlyBudget: jest.fn(),
     upsertCategoryBudgets: jest.fn(),
     evaluateThresholdForMonth: jest.fn(),
@@ -29,7 +30,9 @@ const categoriesHandler = require('@/app/api/expenses/categories/route')
 
 const authorizedUser = { id: 'uid', email: 'a@b.com' }
 const FOOD_CATEGORY_ID = '11111111-1111-4111-8111-111111111111'
+const TRANSIT_CATEGORY_ID = '22222222-2222-4222-8222-222222222222'
 const post = (body) => ({ method: 'POST', body: JSON.stringify(body), headers: { 'content-type': 'application/json' } })
+const deleteBudget = () => ({ method: 'DELETE' })
 
 beforeEach(() => {
   authenticate.mockClear()
@@ -38,6 +41,7 @@ beforeEach(() => {
   budget.getMonthlyBudget.mockClear()
   budget.getMonthlyBudgetConfig.mockClear()
   budget.getOwnedOrGlobalCategoriesByIds.mockClear()
+  budget.deleteCategoryBudget.mockClear()
   budget.upsertMonthlyBudget.mockClear()
   budget.upsertCategoryBudgets.mockClear()
   budget.evaluateThresholdForMonth.mockClear()
@@ -384,6 +388,128 @@ describe('POST /api/budget', () => {
   })
 })
 
+describe('DELETE /api/budget', () => {
+  it('clears one category budget and returns remaining category budgets', async () => {
+    budget.getOwnedOrGlobalCategoriesByIds.mockResolvedValueOnce([{ id: FOOD_CATEGORY_ID }])
+    budget.deleteCategoryBudget.mockResolvedValueOnce({
+      category_id: FOOD_CATEGORY_ID,
+      month: '2026-03-01',
+    })
+    budget.getMonthlyBudgetConfig.mockResolvedValueOnce({
+      month: '2026-03-01',
+      monthly_limit: null,
+      notified: false,
+      category_budgets: [
+        {
+          category_id: TRANSIT_CATEGORY_ID,
+          category_name: 'Transit',
+          category_icon: '🚌',
+          monthly_limit: '25.00',
+        },
+      ],
+    })
+
+    await testApiHandler({
+      appHandler: budgetHandler,
+      url: `http://localhost/api/budget?month=2026-03-01&category_id=${FOOD_CATEGORY_ID}`,
+      async test({ fetch }) {
+        const res = await fetch(deleteBudget())
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+          month: '2026-03-01',
+          monthly_limit: null,
+          notified: false,
+          budget_alert: null,
+          category_budgets: [
+            {
+              category_id: TRANSIT_CATEGORY_ID,
+              category_name: 'Transit',
+              category_icon: '🚌',
+              monthly_limit: '25.00',
+            },
+          ],
+        })
+        expect(budget.getOwnedOrGlobalCategoriesByIds).toHaveBeenCalledWith('uid', [FOOD_CATEGORY_ID])
+        expect(budget.deleteCategoryBudget).toHaveBeenCalledWith('uid', '2026-03-01', FOOD_CATEGORY_ID)
+      }
+    })
+  })
+
+  it('returns an empty budget envelope when clearing the final or missing category budget', async () => {
+    budget.getOwnedOrGlobalCategoriesByIds.mockResolvedValueOnce([{ id: FOOD_CATEGORY_ID }])
+    budget.deleteCategoryBudget.mockResolvedValueOnce(null)
+    budget.getMonthlyBudgetConfig.mockResolvedValueOnce(null)
+
+    await testApiHandler({
+      appHandler: budgetHandler,
+      url: `http://localhost/api/budget?month=2026-03-01&category_id=${FOOD_CATEGORY_ID}`,
+      async test({ fetch }) {
+        const res = await fetch(deleteBudget())
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({
+          month: '2026-03-01',
+          monthly_limit: null,
+          notified: false,
+          budget_alert: null,
+          category_budgets: [],
+        })
+      }
+    })
+  })
+
+  it('returns 400 when category_id is a valid UUID but not owned or global', async () => {
+    budget.getOwnedOrGlobalCategoriesByIds.mockResolvedValueOnce([])
+
+    await testApiHandler({
+      appHandler: budgetHandler,
+      url: `http://localhost/api/budget?month=2026-03-01&category_id=${FOOD_CATEGORY_ID}`,
+      async test({ fetch }) {
+        const res = await fetch(deleteBudget())
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('category_id must reference an owned or global category')
+        expect(budget.getOwnedOrGlobalCategoriesByIds).toHaveBeenCalledWith('uid', [FOOD_CATEGORY_ID])
+        expect(budget.deleteCategoryBudget).not.toHaveBeenCalled()
+      }
+    })
+  })
+
+  it('returns 400 when category_id is missing or invalid', async () => {
+    await testApiHandler({
+      appHandler: budgetHandler,
+      url: 'http://localhost/api/budget?month=2026-03-01',
+      async test({ fetch }) {
+        const res = await fetch(deleteBudget())
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('category_id is required')
+      }
+    })
+
+    await testApiHandler({
+      appHandler: budgetHandler,
+      url: 'http://localhost/api/budget?month=2026-03-01&category_id=cat-1',
+      async test({ fetch }) {
+        const res = await fetch(deleteBudget())
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('category_id must be a valid UUID')
+        expect(budget.deleteCategoryBudget).not.toHaveBeenCalled()
+      }
+    })
+  })
+
+  it('returns 400 when the clear month is invalid', async () => {
+    await testApiHandler({
+      appHandler: budgetHandler,
+      url: `http://localhost/api/budget?month=bad&category_id=${FOOD_CATEGORY_ID}`,
+      async test({ fetch }) {
+        const res = await fetch(deleteBudget())
+        expect(res.status).toBe(400)
+        expect((await res.json()).error).toBe('Valid month is required')
+        expect(budget.deleteCategoryBudget).not.toHaveBeenCalled()
+      }
+    })
+  })
+})
+
 describe('GET /api/budget/summary', () => {
   it('returns the monthly budget summary with category totals and statuses', async () => {
     budget.buildBudgetSummary.mockResolvedValueOnce({
@@ -724,6 +850,29 @@ describe('isPositiveMoneyValue', () => {
     expect(actualBudget.isPositiveMoneyValue('1e2')).toBe(false)
     expect(actualBudget.isPositiveMoneyValue('100000000')).toBe(false)
     expect(actualBudget.isPositiveMoneyValue(100000000)).toBe(false)
+  })
+})
+
+describe('deleteCategoryBudget', () => {
+  it('deletes only the matching user month and category budget row', async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [{ category_id: FOOD_CATEGORY_ID, month: '2026-03-01' }]
+    })
+
+    await expect(actualBudget.deleteCategoryBudget('uid', '2026-03-01', FOOD_CATEGORY_ID)).resolves.toEqual({
+      category_id: FOOD_CATEGORY_ID,
+      month: '2026-03-01',
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM public\.category_budgets[\s\S]*WHERE user_id = \$1 AND month = \$2 AND category_id = \$3[\s\S]*RETURNING category_id, month/),
+      ['uid', '2026-03-01', FOOD_CATEGORY_ID]
+    )
+  })
+
+  it('returns null when there is no matching category budget row to clear', async () => {
+    db.query.mockResolvedValueOnce({ rows: [] })
+
+    await expect(actualBudget.deleteCategoryBudget('uid', '2026-03-01', FOOD_CATEGORY_ID)).resolves.toBeNull()
   })
 })
 

--- a/nextjs/__tests__/budget.test.js
+++ b/nextjs/__tests__/budget.test.js
@@ -1,11 +1,12 @@
 jest.mock('@/lib/auth', () => ({ authenticate: jest.fn() }))
-jest.mock('@/lib/db', () => ({ query: jest.fn() }))
+jest.mock('@/lib/db', () => ({ connect: jest.fn(), query: jest.fn() }))
 jest.mock('@/lib/budget', () => {
   const actual = jest.requireActual('@/lib/budget')
   return {
     ...actual,
     normalizeMonth: jest.fn(actual.normalizeMonth),
     isPositiveMoneyValue: jest.fn(actual.isPositiveMoneyValue),
+    clearCategoryBudgetConfig: jest.fn(),
     getMonthlyBudget: jest.fn(),
     getMonthlyBudgetConfig: jest.fn(),
     getOwnedOrGlobalCategoriesByIds: jest.fn(),
@@ -37,10 +38,12 @@ const deleteBudget = () => ({ method: 'DELETE' })
 beforeEach(() => {
   authenticate.mockClear()
   db.query.mockClear()
+  db.connect.mockClear()
   budget.normalizeMonth.mockClear()
   budget.getMonthlyBudget.mockClear()
   budget.getMonthlyBudgetConfig.mockClear()
   budget.getOwnedOrGlobalCategoriesByIds.mockClear()
+  budget.clearCategoryBudgetConfig.mockClear()
   budget.deleteCategoryBudget.mockClear()
   budget.upsertMonthlyBudget.mockClear()
   budget.upsertCategoryBudgets.mockClear()
@@ -391,11 +394,7 @@ describe('POST /api/budget', () => {
 describe('DELETE /api/budget', () => {
   it('clears one category budget and returns remaining category budgets', async () => {
     budget.getOwnedOrGlobalCategoriesByIds.mockResolvedValueOnce([{ id: FOOD_CATEGORY_ID }])
-    budget.deleteCategoryBudget.mockResolvedValueOnce({
-      category_id: FOOD_CATEGORY_ID,
-      month: '2026-03-01',
-    })
-    budget.getMonthlyBudgetConfig.mockResolvedValueOnce({
+    budget.clearCategoryBudgetConfig.mockResolvedValueOnce({
       month: '2026-03-01',
       monthly_limit: null,
       notified: false,
@@ -430,15 +429,14 @@ describe('DELETE /api/budget', () => {
           ],
         })
         expect(budget.getOwnedOrGlobalCategoriesByIds).toHaveBeenCalledWith('uid', [FOOD_CATEGORY_ID])
-        expect(budget.deleteCategoryBudget).toHaveBeenCalledWith('uid', '2026-03-01', FOOD_CATEGORY_ID)
+        expect(budget.clearCategoryBudgetConfig).toHaveBeenCalledWith('uid', '2026-03-01', FOOD_CATEGORY_ID)
       }
     })
   })
 
   it('returns an empty budget envelope when clearing the final or missing category budget', async () => {
     budget.getOwnedOrGlobalCategoriesByIds.mockResolvedValueOnce([{ id: FOOD_CATEGORY_ID }])
-    budget.deleteCategoryBudget.mockResolvedValueOnce(null)
-    budget.getMonthlyBudgetConfig.mockResolvedValueOnce(null)
+    budget.clearCategoryBudgetConfig.mockResolvedValueOnce(null)
 
     await testApiHandler({
       appHandler: budgetHandler,
@@ -468,7 +466,7 @@ describe('DELETE /api/budget', () => {
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('category_id must reference an owned or global category')
         expect(budget.getOwnedOrGlobalCategoriesByIds).toHaveBeenCalledWith('uid', [FOOD_CATEGORY_ID])
-        expect(budget.deleteCategoryBudget).not.toHaveBeenCalled()
+        expect(budget.clearCategoryBudgetConfig).not.toHaveBeenCalled()
       }
     })
   })
@@ -491,7 +489,7 @@ describe('DELETE /api/budget', () => {
         const res = await fetch(deleteBudget())
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('category_id must be a valid UUID')
-        expect(budget.deleteCategoryBudget).not.toHaveBeenCalled()
+        expect(budget.clearCategoryBudgetConfig).not.toHaveBeenCalled()
       }
     })
   })
@@ -504,7 +502,7 @@ describe('DELETE /api/budget', () => {
         const res = await fetch(deleteBudget())
         expect(res.status).toBe(400)
         expect((await res.json()).error).toBe('Valid month is required')
-        expect(budget.deleteCategoryBudget).not.toHaveBeenCalled()
+        expect(budget.clearCategoryBudgetConfig).not.toHaveBeenCalled()
       }
     })
   })
@@ -873,6 +871,64 @@ describe('deleteCategoryBudget', () => {
     db.query.mockResolvedValueOnce({ rows: [] })
 
     await expect(actualBudget.deleteCategoryBudget('uid', '2026-03-01', FOOD_CATEGORY_ID)).resolves.toBeNull()
+  })
+})
+
+describe('clearCategoryBudgetConfig', () => {
+  it('deletes and reads the updated budget config in one transaction', async () => {
+    const client = {
+      query: jest.fn()
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ rows: [{ category_id: FOOD_CATEGORY_ID, month: '2026-03-01' }] })
+        .mockResolvedValueOnce({ rows: [{ month: '2026-03-01', monthly_limit: '100.00', notified: false }] })
+        .mockResolvedValueOnce({
+          rows: [{
+            category_id: TRANSIT_CATEGORY_ID,
+            category_name: 'Transit',
+            category_icon: '🚌',
+            monthly_limit: '25.00',
+          }],
+        })
+        .mockResolvedValueOnce({}),
+      release: jest.fn(),
+    }
+    db.connect.mockResolvedValueOnce(client)
+
+    await expect(actualBudget.clearCategoryBudgetConfig('uid', '2026-03-01', FOOD_CATEGORY_ID)).resolves.toEqual({
+      month: '2026-03-01',
+      monthly_limit: '100.00',
+      notified: false,
+      category_budgets: [{
+        category_id: TRANSIT_CATEGORY_ID,
+        category_name: 'Transit',
+        category_icon: '🚌',
+        monthly_limit: '25.00',
+      }],
+    })
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN')
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/DELETE FROM public\.category_budgets/),
+      ['uid', '2026-03-01', FOOD_CATEGORY_ID]
+    )
+    expect(client.query).toHaveBeenLastCalledWith('COMMIT')
+    expect(client.release).toHaveBeenCalled()
+  })
+
+  it('rolls back when the post-delete config read fails', async () => {
+    const client = {
+      query: jest.fn()
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ rows: [{ category_id: FOOD_CATEGORY_ID, month: '2026-03-01' }] })
+        .mockRejectedValueOnce(new Error('read failed'))
+        .mockResolvedValueOnce({}),
+      release: jest.fn(),
+    }
+    db.connect.mockResolvedValueOnce(client)
+
+    await expect(actualBudget.clearCategoryBudgetConfig('uid', '2026-03-01', FOOD_CATEGORY_ID)).rejects.toThrow('read failed')
+    expect(client.query).toHaveBeenLastCalledWith('ROLLBACK')
+    expect(client.release).toHaveBeenCalled()
   })
 })
 

--- a/nextjs/__tests__/frontend/planner.test.js
+++ b/nextjs/__tests__/frontend/planner.test.js
@@ -13,6 +13,7 @@ jest.mock('@/lib/apiClient', () => ({
       this.status = status
     }
   },
+  apiDelete: jest.fn(),
   apiGet: jest.fn(),
   apiPost: jest.fn(),
 }))
@@ -65,7 +66,7 @@ const React = require('react')
 const { render, screen, waitFor, cleanup, act, fireEvent } = require('@testing-library/react')
 const { useRouter } = require('next/navigation')
 const { useAuth, useDataChanged, useDataMode } = require('@/components/providers')
-const { ApiError, apiGet, apiPost } = require('@/lib/apiClient')
+const { ApiError, apiDelete, apiGet, apiPost } = require('@/lib/apiClient')
 const PlannerView = require('@/components/planner-view').default
 
 async function flushAsyncUpdates() {
@@ -332,6 +333,287 @@ describe('PlannerView', () => {
     expect(screen.getByText('Actual spend')).toBeTruthy()
     expect(screen.getAllByText('Food').length).toBeGreaterThan(0)
     expect(screen.getByText('Save update')).toBeTruthy()
+  })
+
+  it('clears one saved category plan and leaves other category plans intact', async () => {
+    apiGet
+      .mockResolvedValueOnce([
+        { id: 'cat-food', name: 'Food', icon: null },
+        { id: 'cat-fun', name: 'Fun', icon: null },
+      ])
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: null,
+        category_budgets: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '120.00' },
+          { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: null,
+        total_budget: '200.00',
+        total_expenses: '50.00',
+        total_income: '1000.00',
+        remaining_budget: '150.00',
+        threshold_exceeded: false,
+        category_statuses: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '120.00', spent: '20.00' },
+          { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00', spent: '30.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: null,
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: {
+          active_count: 0,
+          current_total: '0.00',
+          remaining_total: '0.00',
+          monthly_required_total: '0.00',
+          available_after_goal_contributions: null,
+          pressure_level: 'none',
+        },
+      })
+    apiDelete.mockResolvedValueOnce({
+      month: '2026-03-01',
+      monthly_limit: null,
+      notified: false,
+      budget_alert: null,
+      category_budgets: [
+        { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00' },
+      ],
+    })
+
+    await renderPlanner()
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+
+    apiGet
+      .mockResolvedValueOnce([
+        { id: 'cat-food', name: 'Food', icon: null },
+        { id: 'cat-fun', name: 'Fun', icon: null },
+      ])
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: null,
+        category_budgets: [
+          { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: null,
+        total_budget: '80.00',
+        total_expenses: '50.00',
+        total_income: '1000.00',
+        remaining_budget: '30.00',
+        threshold_exceeded: false,
+        category_statuses: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: null, spent: '20.00' },
+          { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00', spent: '30.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: null,
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: {
+          active_count: 0,
+          current_total: '0.00',
+          remaining_total: '0.00',
+          monthly_required_total: '0.00',
+          available_after_goal_contributions: null,
+          pressure_level: 'none',
+        },
+      })
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole('button', { name: 'Clear plan' })[0])
+      await flushAsyncUpdates()
+    })
+
+    expect(apiDelete).toHaveBeenCalledWith(
+      '/api/budget?month=2026-03-01&category_id=cat-food',
+      { accessToken: 'test-token' }
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Food plan cleared for 2026-03-01.')).toBeTruthy()
+      expect(screen.getByText('Not set')).toBeTruthy()
+    })
+    expect(screen.getAllByDisplayValue('').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByDisplayValue('80.00')).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'Clear plan' })).toHaveLength(1)
+  })
+
+  it('shows inline validation feedback for invalid category amount drafts', async () => {
+    mockPlannerResponses()
+
+    await renderPlanner()
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+
+    const input = screen.getByLabelText('Plan amount ($)')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '-5' } })
+      await flushAsyncUpdates()
+    })
+    expect(screen.getByText('Amount cannot be negative.')).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'abc' } })
+      await flushAsyncUpdates()
+    })
+    expect(screen.getByText('Enter a valid dollar amount.')).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '1.005' } })
+      await flushAsyncUpdates()
+    })
+    const decimalMessage = screen.getByText('Enter a dollar amount with no more than 2 decimal places.')
+    expect(decimalMessage).toBeTruthy()
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect(input.getAttribute('aria-describedby')).toBe(decimalMessage.id)
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '0' } })
+      await flushAsyncUpdates()
+    })
+    expect(screen.getByText('Enter an amount greater than $0.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Save plan' }).disabled).toBe(true)
+  })
+
+  it('points zero drafts on saved rows to the clear action', async () => {
+    apiGet
+      .mockResolvedValueOnce([
+        { id: 'cat-food', name: 'Food', icon: null },
+      ])
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: null,
+        category_budgets: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '120.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: null,
+        total_budget: '120.00',
+        total_expenses: '20.00',
+        total_income: '1000.00',
+        remaining_budget: '100.00',
+        threshold_exceeded: false,
+        category_statuses: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '120.00', spent: '20.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: null,
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: {
+          active_count: 0,
+          current_total: '0.00',
+          remaining_total: '0.00',
+          monthly_required_total: '0.00',
+          available_after_goal_contributions: null,
+          pressure_level: 'none',
+        },
+      })
+
+    await renderPlanner()
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Plan amount ($)'), { target: { value: '0' } })
+      await flushAsyncUpdates()
+    })
+
+    expect(screen.getByText('Use Clear plan to return this category to Not set.')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Save update' }).disabled).toBe(true)
+    expect(screen.getByRole('button', { name: 'Clear plan' }).disabled).toBe(false)
+  })
+
+  it('preserves positive decimal category budget saves', async () => {
+    mockPlannerResponses()
+    apiPost.mockResolvedValueOnce({
+      month: '2026-03-01',
+      monthly_limit: '1000.00',
+      notified: false,
+      budget_alert: null,
+      category_budgets: [
+        { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '49.23' },
+      ],
+    })
+
+    await renderPlanner()
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+
+    apiGet
+      .mockResolvedValueOnce([
+        { id: 'cat-food', name: 'Food', icon: null },
+      ])
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: '1000.00',
+        category_budgets: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '49.23' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-03-01',
+        monthly_limit: '1000.00',
+        total_budget: '1000.00',
+        total_expenses: '200.00',
+        total_income: '1200.00',
+        remaining_budget: '800.00',
+        threshold_exceeded: false,
+        category_statuses: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '49.23', spent: '20.00' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: null,
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: {
+          active_count: 0,
+          current_total: '0.00',
+          remaining_total: '0.00',
+          monthly_required_total: '0.00',
+          available_after_goal_contributions: null,
+          pressure_level: 'none',
+        },
+      })
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Plan amount ($)'), { target: { value: '49.23' } })
+      await flushAsyncUpdates()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save plan' }))
+      await flushAsyncUpdates()
+    })
+
+    expect(apiPost).toHaveBeenCalledWith(
+      '/api/budget',
+      {
+        month: '2026-03-01',
+        category_budgets: [{ category_id: 'cat-food', monthly_limit: 49.23 }],
+      },
+      { accessToken: 'test-token' }
+    )
+    await waitFor(() => expect(screen.getByDisplayValue('49.23')).toBeTruthy())
   })
 
   it('opens the inline Add goal form from the savings goals CTA', async () => {

--- a/nextjs/__tests__/frontend/planner.test.js
+++ b/nextjs/__tests__/frontend/planner.test.js
@@ -639,6 +639,47 @@ describe('PlannerView', () => {
     await waitFor(() => expect(screen.getByDisplayValue('49.23')).toBeTruthy())
   })
 
+  it('disables the overall cap save while a category plan save is in flight', async () => {
+    mockPlannerResponses()
+    let resolveCategorySave
+    apiPost.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveCategorySave = resolve
+    }))
+
+    await renderPlanner()
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Overall monthly cap'), { target: { value: '1200' } })
+      await flushAsyncUpdates()
+    })
+    expect(screen.getByRole('button', { name: 'Update cap' }).disabled).toBe(false)
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Plan amount ($)'), { target: { value: '49.23' } })
+      await flushAsyncUpdates()
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save plan' }))
+      await flushAsyncUpdates()
+    })
+
+    expect(screen.getByRole('button', { name: 'Update cap' }).disabled).toBe(true)
+
+    await act(async () => {
+      resolveCategorySave({
+        month: '2026-03-01',
+        monthly_limit: '1000.00',
+        notified: false,
+        budget_alert: null,
+        category_budgets: [
+          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: '49.23' },
+        ],
+      })
+      await flushAsyncUpdates()
+    })
+  })
+
   it('opens the inline Add goal form from the savings goals CTA', async () => {
     mockPlannerResponses()
 

--- a/nextjs/__tests__/frontend/planner.test.js
+++ b/nextjs/__tests__/frontend/planner.test.js
@@ -335,7 +335,7 @@ describe('PlannerView', () => {
     expect(screen.getByText('Save update')).toBeTruthy()
   })
 
-  it('clears one saved category plan and leaves other category plans intact', async () => {
+  it('clears one saved category plan immediately, recomputes summary totals, and does not refetch', async () => {
     apiGet
       .mockResolvedValueOnce([
         { id: 'cat-food', name: 'Food', icon: null },
@@ -390,6 +390,7 @@ describe('PlannerView', () => {
 
     await renderPlanner()
     await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+    expect(screen.getByText('$150.00 left')).toBeTruthy()
 
     await act(async () => {
       fireEvent.click(screen.getAllByRole('button', { name: 'Clear plan' })[0])
@@ -406,6 +407,9 @@ describe('PlannerView', () => {
     })
     expect(screen.getAllByDisplayValue('').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByDisplayValue('80.00')).toBeTruthy()
+    expect(screen.queryByText('$150.00 left')).toBeNull()
+    expect(screen.getByText('$30.00 left')).toBeTruthy()
+    expect(screen.getByText('$30.00 under plan')).toBeTruthy()
     expect(screen.getAllByRole('button', { name: 'Clear plan' })).toHaveLength(1)
     expect(apiGet).toHaveBeenCalledTimes(5)
   })

--- a/nextjs/__tests__/frontend/planner.test.js
+++ b/nextjs/__tests__/frontend/planner.test.js
@@ -391,48 +391,6 @@ describe('PlannerView', () => {
     await renderPlanner()
     await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
 
-    apiGet
-      .mockResolvedValueOnce([
-        { id: 'cat-food', name: 'Food', icon: null },
-        { id: 'cat-fun', name: 'Fun', icon: null },
-      ])
-      .mockResolvedValueOnce({
-        month: '2026-03-01',
-        monthly_limit: null,
-        category_budgets: [
-          { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00' },
-        ],
-      })
-      .mockResolvedValueOnce({
-        month: '2026-03-01',
-        monthly_limit: null,
-        total_budget: '80.00',
-        total_expenses: '50.00',
-        total_income: '1000.00',
-        remaining_budget: '30.00',
-        threshold_exceeded: false,
-        category_statuses: [
-          { category_id: 'cat-food', category_name: 'Food', category_icon: null, monthly_limit: null, spent: '20.00' },
-          { category_id: 'cat-fun', category_name: 'Fun', category_icon: null, monthly_limit: '80.00', spent: '30.00' },
-        ],
-      })
-      .mockResolvedValueOnce({
-        month: '2026-02-01',
-        monthly_limit: null,
-        category_budgets: [],
-      })
-      .mockResolvedValueOnce({
-        goals: [],
-        summary: {
-          active_count: 0,
-          current_total: '0.00',
-          remaining_total: '0.00',
-          monthly_required_total: '0.00',
-          available_after_goal_contributions: null,
-          pressure_level: 'none',
-        },
-      })
-
     await act(async () => {
       fireEvent.click(screen.getAllByRole('button', { name: 'Clear plan' })[0])
       await flushAsyncUpdates()
@@ -449,6 +407,7 @@ describe('PlannerView', () => {
     expect(screen.getAllByDisplayValue('').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByDisplayValue('80.00')).toBeTruthy()
     expect(screen.getAllByRole('button', { name: 'Clear plan' })).toHaveLength(1)
+    expect(apiGet).toHaveBeenCalledTimes(5)
   })
 
   it('shows inline validation feedback for invalid category amount drafts', async () => {

--- a/nextjs/__tests__/frontend/planner.test.js
+++ b/nextjs/__tests__/frontend/planner.test.js
@@ -476,6 +476,8 @@ describe('PlannerView', () => {
     })
     const decimalMessage = screen.getByText('Enter a dollar amount with no more than 2 decimal places.')
     expect(decimalMessage).toBeTruthy()
+    expect(decimalMessage.getAttribute('role')).toBe('status')
+    expect(decimalMessage.getAttribute('aria-live')).toBe('polite')
     expect(input.getAttribute('aria-invalid')).toBe('true')
     expect(input.getAttribute('aria-describedby')).toBe(decimalMessage.id)
 
@@ -485,6 +487,27 @@ describe('PlannerView', () => {
     })
     expect(screen.getByText('Enter an amount greater than $0.')).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Save plan' }).disabled).toBe(true)
+  })
+
+  it('shows inline validation feedback for invalid overall cap drafts', async () => {
+    mockPlannerResponses()
+
+    await renderPlanner()
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+
+    const input = screen.getByLabelText('Overall monthly cap')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '1.005' } })
+      await flushAsyncUpdates()
+    })
+
+    const decimalMessage = screen.getByText('Enter a dollar amount with no more than 2 decimal places.')
+    expect(decimalMessage).toBeTruthy()
+    expect(decimalMessage.getAttribute('role')).toBe('status')
+    expect(decimalMessage.getAttribute('aria-live')).toBe('polite')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect(input.getAttribute('aria-describedby')).toBe(decimalMessage.id)
+    expect(screen.getByRole('button', { name: 'Update cap' }).disabled).toBe(true)
   })
 
   it('points zero drafts on saved rows to the clear action', async () => {

--- a/nextjs/__tests__/lib.planner.test.js
+++ b/nextjs/__tests__/lib.planner.test.js
@@ -340,6 +340,7 @@ describe('planner money normalization', () => {
     expect(normalizeMoneyDraftForSave('1.005')).toBeNull()
     expect(normalizeMoneyDraftForSave('1.105')).toBeNull()
     expect(normalizeMoneyDraftForSave('100000000.00')).toBeNull()
+    expect(normalizeMoneyDraftForSave('1'.repeat(1000))).toBeNull()
     expect(normalizeMoneyDraftForSave('0.004')).toBeNull()
     expect(normalizeMoneyDraftForSave('1e1000')).toBeNull()
     expect(normalizeMoneyDraftForSave('')).toBeNull()

--- a/nextjs/__tests__/lib.planner.test.js
+++ b/nextjs/__tests__/lib.planner.test.js
@@ -5,6 +5,7 @@ const {
   buildPlannerRows,
   buildPlannerSummary,
   formatMoneyDraftValue,
+  getPlannerAmountDraftValidation,
   getCopyLastMonthState,
   getPlannerAdjacentMonths,
   mergePlannerDrafts,
@@ -333,15 +334,59 @@ describe('planner money normalization', () => {
   })
 
   it('normalizes valid save drafts to the stored two-decimal number shape', () => {
-    expect(normalizeMoneyDraftForSave('1.005')).toBe(1.01)
-    expect(normalizeMoneyDraftForSave('1.105')).toBe(1.11)
     expect(normalizeMoneyDraftForSave('80')).toBe(80)
     expect(normalizeMoneyDraftForSave('1.')).toBe(1)
     expect(normalizeMoneyDraftForSave('99999999.99')).toBe(99999999.99)
+    expect(normalizeMoneyDraftForSave('1.005')).toBeNull()
+    expect(normalizeMoneyDraftForSave('1.105')).toBeNull()
     expect(normalizeMoneyDraftForSave('100000000.00')).toBeNull()
     expect(normalizeMoneyDraftForSave('0.004')).toBeNull()
     expect(normalizeMoneyDraftForSave('1e1000')).toBeNull()
     expect(normalizeMoneyDraftForSave('')).toBeNull()
+  })
+})
+
+describe('planner amount draft validation', () => {
+  it('accepts positive decimal drafts and returns the normalized amount', () => {
+    expect(getPlannerAmountDraftValidation('49.23')).toEqual({
+      isValid: true,
+      message: '',
+      kind: 'valid',
+      amount: 49.23,
+    })
+  })
+
+  it('returns clear validation messages for invalid category amount drafts', () => {
+    expect(getPlannerAmountDraftValidation('-5')).toEqual({
+      isValid: false,
+      message: 'Amount cannot be negative.',
+      kind: 'negative',
+    })
+    expect(getPlannerAmountDraftValidation('abc')).toEqual({
+      isValid: false,
+      message: 'Enter a valid dollar amount.',
+      kind: 'malformed',
+    })
+    expect(getPlannerAmountDraftValidation('1.005')).toEqual({
+      isValid: false,
+      message: 'Enter a dollar amount with no more than 2 decimal places.',
+      kind: 'too_many_decimals',
+    })
+    expect(getPlannerAmountDraftValidation('0')).toEqual({
+      isValid: false,
+      message: 'Enter an amount greater than $0.',
+      kind: 'zero',
+    })
+    expect(getPlannerAmountDraftValidation('0', { hasSavedPlan: true })).toEqual({
+      isValid: false,
+      message: 'Use Clear plan to return this category to Not set.',
+      kind: 'zero',
+    })
+    expect(getPlannerAmountDraftValidation('')).toEqual({
+      isValid: false,
+      message: '',
+      kind: 'empty',
+    })
   })
 })
 

--- a/nextjs/e2e/transactions.spec.js
+++ b/nextjs/e2e/transactions.spec.js
@@ -174,7 +174,8 @@ test('Planner: expense and category budget update budget health with cleanup', a
 
   categoryName = (await editableRow.locator('.planner-row__copy strong').innerText()).trim()
   originalBudget = await editableRow.locator('input').inputValue()
-  hadExistingBudget = (await editableRow.getByRole('button').innerText()).trim() === 'Save update'
+  const initialSaveButton = editableRow.getByRole('button', { name: /Save update|Save plan/ })
+  hadExistingBudget = (await initialSaveButton.innerText()).trim() === 'Save update'
   const originalActual = await readCurrency(
     editableRow.locator('.planner-row__metrics > div').nth(1).locator('strong')
   )

--- a/nextjs/src/app/api/budget/route.js
+++ b/nextjs/src/app/api/budget/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { authenticate } from '@/lib/auth'
 import {
-  deleteCategoryBudget,
+  clearCategoryBudgetConfig,
   evaluateThresholdForMonth,
   getMonthlyBudgetConfig,
   getOwnedOrGlobalCategoriesByIds,
@@ -137,8 +137,7 @@ export async function DELETE(request) {
       return NextResponse.json({ error: 'category_id must reference an owned or global category' }, { status: 400 })
     }
 
-    await deleteCategoryBudget(user.id, month, categoryId)
-    const savedBudget = await getMonthlyBudgetConfig(user.id, month)
+    const savedBudget = await clearCategoryBudgetConfig(user.id, month, categoryId)
 
     return NextResponse.json({
       month: savedBudget?.month ?? month,

--- a/nextjs/src/app/api/budget/route.js
+++ b/nextjs/src/app/api/budget/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { authenticate } from '@/lib/auth'
 import {
+  deleteCategoryBudget,
   evaluateThresholdForMonth,
   getMonthlyBudgetConfig,
   getOwnedOrGlobalCategoriesByIds,
@@ -113,5 +114,40 @@ export async function POST(request) {
     })
   } catch {
     return NextResponse.json({ error: 'Failed to save budget' }, { status: 500 })
+  }
+}
+
+export async function DELETE(request) {
+  const { user, error } = await authenticate(request)
+  if (error) return error
+
+  const params = new URL(request.url).searchParams
+  const month = normalizeMonth(params.get('month'))
+  const categoryId = params.get('category_id')
+
+  if (!month) return NextResponse.json({ error: 'Valid month is required' }, { status: 400 })
+  if (!categoryId) return NextResponse.json({ error: 'category_id is required' }, { status: 400 })
+  if (!UUID_PATTERN.test(categoryId)) {
+    return NextResponse.json({ error: 'category_id must be a valid UUID' }, { status: 400 })
+  }
+
+  try {
+    const validCategories = await getOwnedOrGlobalCategoriesByIds(user.id, [categoryId])
+    if (validCategories.length !== 1) {
+      return NextResponse.json({ error: 'category_id must reference an owned or global category' }, { status: 400 })
+    }
+
+    await deleteCategoryBudget(user.id, month, categoryId)
+    const savedBudget = await getMonthlyBudgetConfig(user.id, month)
+
+    return NextResponse.json({
+      month: savedBudget?.month ?? month,
+      monthly_limit: savedBudget?.monthly_limit ?? null,
+      notified: savedBudget?.notified ?? false,
+      budget_alert: null,
+      category_budgets: savedBudget?.category_budgets ?? [],
+    })
+  } catch {
+    return NextResponse.json({ error: 'Failed to clear category budget' }, { status: 500 })
   }
 }

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -6969,8 +6969,27 @@ html[data-theme='dark'] .planner-row__progress-track {
   align-items: end;
 }
 
-.planner-row__editor .button-secondary {
+.planner-row__validation {
+  color: var(--danger);
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.planner-row__actions {
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.planner-row__actions .button-secondary {
   min-width: 9rem;
+}
+
+.planner-row__clear {
+  color: var(--danger);
 }
 
 @media (max-width: 880px) {
@@ -6991,6 +7010,14 @@ html[data-theme='dark'] .planner-row__progress-track {
   .planner-row__metrics,
   .planner-row__editor {
     grid-template-columns: 1fr;
+  }
+
+  .planner-row__actions {
+    justify-content: stretch;
+  }
+
+  .planner-row__actions .button-secondary {
+    flex: 1 1 9rem;
   }
 }
 

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -6969,6 +6969,7 @@ html[data-theme='dark'] .planner-row__progress-track {
   align-items: end;
 }
 
+.planner-summary__validation,
 .planner-row__validation {
   color: var(--danger);
   font-size: 0.82rem;

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -497,8 +497,10 @@ export default function PlannerView() {
     : actualSpendState === 'loading'
       ? 'Waiting for the live budget summary to load.'
       : 'The live budget summary is unavailable, so actual spend is not being guessed.'
-  const normalizedOverallDraft = normalizeMoneyDraftForSave(overallDraft)
+  const overallDraftValidation = getPlannerAmountDraftValidation(overallDraft)
+  const normalizedOverallDraft = overallDraftValidation.amount ?? null
   const normalizedOverallLimit = normalizeMoneyDraftForSave(plannerSummary.overallLimit)
+  const overallValidationMessageId = 'planner-overall-cap-validation'
   const planDeltaTone = !plannerSummary.hasActualSpendData || plannerSummary.remainingTotal == null
     ? 'neutral'
     : plannerSummary.remainingTotal < 0
@@ -571,7 +573,7 @@ export default function PlannerView() {
     event.preventDefault()
     if (isSampleMode || savingTarget) return
 
-    const nextLimit = normalizeMoneyDraftForSave(overallDraft)
+    const nextLimit = getPlannerAmountDraftValidation(overallDraft).amount ?? null
     if (nextLimit == null) return
 
     setSavingTarget('overall')
@@ -1027,6 +1029,8 @@ export default function PlannerView() {
           <label className="planner-summary__field">
             <span>Overall monthly cap</span>
             <input
+              aria-describedby={overallDraftValidation.message ? overallValidationMessageId : undefined}
+              aria-invalid={overallDraftValidation.message ? 'true' : undefined}
               className="input-field"
               disabled={isSampleMode}
               inputMode="decimal"
@@ -1041,6 +1045,16 @@ export default function PlannerView() {
               type="number"
               value={overallDraft}
             />
+            {overallDraftValidation.message ? (
+              <small
+                aria-live="polite"
+                className="planner-summary__validation"
+                id={overallValidationMessageId}
+                role="status"
+              >
+                {overallDraftValidation.message}
+              </small>
+            ) : null}
           </label>
 
           <div className={`planner-summary__form-copy planner-summary__form-copy--${overallCapTone}`}>
@@ -1417,7 +1431,12 @@ export default function PlannerView() {
                         value={rowDraft}
                       />
                       {rowDraftValidation.message ? (
-                        <small className="planner-row__validation" id={validationMessageId} role="alert">
+                        <small
+                          aria-live="polite"
+                          className="planner-row__validation"
+                          id={validationMessageId}
+                          role="status"
+                        >
                           {rowDraftValidation.message}
                         </small>
                       ) : null}

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -1066,7 +1066,7 @@ export default function PlannerView() {
             className="button-primary"
             disabled={
               isSampleMode
-              || savingTarget === 'overall'
+              || Boolean(savingTarget)
               || normalizedOverallDraft == null
               || normalizedOverallDraft === normalizedOverallLimit
             }

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth, useDataChanged, useDataMode } from '@/components/providers'
-import { ApiError, apiGet, apiPost } from '@/lib/apiClient'
+import { ApiError, apiDelete, apiGet, apiPost } from '@/lib/apiClient'
 import { DEMO_MONTH, demoBudgetSummary, demoCategoryBudgets, demoSavingsGoals } from '@/lib/demoData'
 import { getCategoryPresentation } from '@/lib/financeVisuals'
 import {
@@ -23,6 +23,7 @@ import {
   buildCopyLastMonthPayload,
   buildPlannerRows,
   buildPlannerSummary,
+  getPlannerAmountDraftValidation,
   getCopyLastMonthState,
   getPlannerAdjacentMonths,
   mergePlannerDrafts,
@@ -621,8 +622,11 @@ export default function PlannerView() {
     if (isSampleMode || savingTarget || !row.isEditable) return
 
     const draftValue = rowDrafts[row.id]
-    const nextLimit = normalizeMoneyDraftForSave(draftValue)
-    if (nextLimit == null) return
+    const draftValidation = getPlannerAmountDraftValidation(draftValue, {
+      hasSavedPlan: row.hasSavedPlan,
+    })
+    if (!draftValidation.isValid) return
+    const nextLimit = draftValidation.amount
 
     setSavingTarget(row.id)
     try {
@@ -680,6 +684,68 @@ export default function PlannerView() {
           icon: row.categoryIcon,
           kind: 'expense',
         }).label} plan saved for ${formatMonthPeriod(activeMonth)}.`,
+      })
+      handleRetry()
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        handleAuthError()
+        return
+      }
+
+      setFeedback({
+        tone: 'warning',
+        message: getErrorMessage(error),
+      })
+    } finally {
+      setSavingTarget('')
+    }
+  }
+
+  const handleClearCategory = async (row) => {
+    if (isSampleMode || savingTarget || !row.isEditable || !row.hasSavedPlan) return
+
+    setSavingTarget(`clear:${row.id}`)
+    try {
+      const params = new URLSearchParams({
+        month: activeMonth,
+        category_id: row.categoryId,
+      })
+      await apiDelete(`/api/budget?${params.toString()}`, {
+        accessToken: session.accessToken,
+      })
+
+      setLiveState((current) => {
+        if (current.month !== activeMonth) return current
+
+        const categoryBudgets = (current.config?.category_budgets ?? [])
+          .filter((budget) => budget.category_id !== row.categoryId)
+
+        return {
+          ...current,
+          config: {
+            month: activeMonth,
+            monthly_limit: current.config?.monthly_limit ?? null,
+            category_budgets: categoryBudgets,
+          },
+        }
+      })
+      dirtyRowIdsRef.current.delete(row.id)
+      rowDraftsRef.current = {
+        ...rowDraftsRef.current,
+        [row.id]: '',
+      }
+      setRowDrafts((current) => ({
+        ...current,
+        [row.id]: '',
+      }))
+      notifyDataChanged()
+      setFeedback({
+        tone: 'success',
+        message: `${getCategoryPresentation({
+          name: row.categoryName,
+          icon: row.categoryIcon,
+          kind: 'expense',
+        }).label} plan cleared for ${formatMonthPeriod(activeMonth)}.`,
       })
       handleRetry()
     } catch (error) {
@@ -1262,9 +1328,13 @@ export default function PlannerView() {
                 kind: 'expense',
               })
               const rowDraft = rowDrafts[row.id] ?? ''
-              const normalizedRowDraft = normalizeMoneyDraftForSave(rowDraft)
+              const rowDraftValidation = getPlannerAmountDraftValidation(rowDraft, {
+                hasSavedPlan: row.hasSavedPlan,
+              })
+              const normalizedRowDraft = rowDraftValidation.amount ?? null
               const normalizedPlannedAmount = normalizeMoneyDraftForSave(row.plannedAmount)
-              const hasValidDraft = normalizedRowDraft != null
+              const hasValidDraft = rowDraftValidation.isValid
+              const validationMessageId = `planner-row-${row.id}-validation`
               const isUnchanged = hasValidDraft
                 && normalizedPlannedAmount != null
                 && normalizedRowDraft === normalizedPlannedAmount
@@ -1336,32 +1406,53 @@ export default function PlannerView() {
                     <label className="planner-row__field">
                       <span>{row.isEditable ? 'Plan amount ($)' : 'Plan amount'}</span>
                       <input
+                        aria-describedby={rowDraftValidation.message ? validationMessageId : undefined}
+                        aria-invalid={rowDraftValidation.message ? 'true' : undefined}
                         className="input-field"
                         disabled={isSampleMode || !row.isEditable}
                         inputMode="decimal"
-                        min="0.01"
                         onChange={(event) => handleRowDraftChange(row.id, event.target.value)}
                         placeholder={row.isEditable ? 'e.g. 250' : 'Read-only'}
-                        step="0.01"
-                        type="number"
+                        type="text"
                         value={rowDraft}
                       />
+                      {rowDraftValidation.message ? (
+                        <small className="planner-row__validation" id={validationMessageId} role="alert">
+                          {rowDraftValidation.message}
+                        </small>
+                      ) : null}
                     </label>
 
-                    <button
-                      className="button-secondary"
-                      disabled={
-                        isSampleMode
-                        || !row.isEditable
-                        || savingTarget === row.id
-                        || !hasValidDraft
-                        || isUnchanged
-                      }
-                      onClick={() => handleSaveCategory(row)}
-                      type="button"
-                    >
-                      {savingTarget === row.id ? 'Saving...' : row.hasSavedPlan ? 'Save update' : 'Save plan'}
-                    </button>
+                    <div className="planner-row__actions">
+                      <button
+                        className="button-secondary"
+                        disabled={
+                          isSampleMode
+                          || !row.isEditable
+                          || Boolean(savingTarget)
+                          || !hasValidDraft
+                          || isUnchanged
+                        }
+                        onClick={() => handleSaveCategory(row)}
+                        type="button"
+                      >
+                        {savingTarget === row.id ? 'Saving...' : row.hasSavedPlan ? 'Save update' : 'Save plan'}
+                      </button>
+                      {row.hasSavedPlan ? (
+                        <button
+                          className="button-secondary planner-row__clear"
+                          disabled={
+                            isSampleMode
+                            || !row.isEditable
+                            || Boolean(savingTarget)
+                          }
+                          onClick={() => handleClearCategory(row)}
+                          type="button"
+                        >
+                          {savingTarget === `clear:${row.id}` ? 'Clearing...' : 'Clear plan'}
+                        </button>
+                      ) : null}
+                    </div>
                   </div>
                 </article>
               )

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -73,6 +73,53 @@ function buildSampleCategories() {
   }))
 }
 
+function toSummaryMoneyNumber(value) {
+  if (value == null || value === '') return null
+
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) return null
+  return Number(amount.toFixed(2))
+}
+
+function toSummaryMoneyString(value) {
+  return Number(value ?? 0).toFixed(2)
+}
+
+function updateSummaryAfterCategoryClear(summary, categoryBudgets, clearedCategoryId) {
+  if (!summary) return summary
+
+  const categoryBudgetTotal = categoryBudgets.reduce((sum, budget) => {
+    const amount = toSummaryMoneyNumber(budget.monthly_limit)
+    return amount == null ? sum : sum + amount
+  }, 0)
+  const categoryBudgetTotalText = toSummaryMoneyString(categoryBudgetTotal)
+  const monthlyLimit = summary.monthly_limit ?? null
+  const totalBudget = monthlyLimit ?? (categoryBudgets.length ? categoryBudgetTotalText : null)
+  const totalBudgetNumber = toSummaryMoneyNumber(totalBudget)
+  const totalExpenses = toSummaryMoneyNumber(summary.total_expenses) ?? 0
+
+  return {
+    ...summary,
+    category_budget_total: categoryBudgetTotalText,
+    total_budget: totalBudget,
+    remaining_budget: totalBudgetNumber == null
+      ? null
+      : toSummaryMoneyString(totalBudgetNumber - totalExpenses),
+    threshold_exceeded: totalBudgetNumber == null ? false : totalExpenses >= totalBudgetNumber,
+    category_statuses: (summary.category_statuses ?? []).map((status) => (
+      status.category_id === clearedCategoryId
+        ? {
+            ...status,
+            monthly_limit: null,
+            remaining_budget: null,
+            threshold_exceeded: false,
+            progress_percentage: 0,
+          }
+        : status
+    )),
+  }
+}
+
 function LiveNotice({ message, onRetry }) {
   if (!message) return null
 
@@ -739,16 +786,7 @@ export default function PlannerView() {
             monthly_limit: current.config?.monthly_limit ?? null,
             category_budgets: categoryBudgets,
           },
-          summary: current.summary
-            ? {
-                ...current.summary,
-                category_statuses: (current.summary.category_statuses ?? []).map((status) => (
-                  status.category_id === row.categoryId
-                    ? { ...status, monthly_limit: null }
-                    : status
-                )),
-              }
-            : current.summary,
+          summary: updateSummaryAfterCategoryClear(current.summary, categoryBudgets, row.categoryId),
         }
       })
       dirtyRowIdsRef.current.delete(row.id)

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -667,6 +667,16 @@ export default function PlannerView() {
             monthly_limit: current.config?.monthly_limit ?? null,
             category_budgets: categoryBudgets,
           },
+          summary: current.summary
+            ? {
+                ...current.summary,
+                category_statuses: (current.summary.category_statuses ?? []).map((status) => (
+                  status.category_id === row.categoryId
+                    ? { ...status, monthly_limit: nextLimit }
+                    : status
+                )),
+              }
+            : current.summary,
         }
       })
       dirtyRowIdsRef.current.delete(row.id)
@@ -729,6 +739,16 @@ export default function PlannerView() {
             monthly_limit: current.config?.monthly_limit ?? null,
             category_budgets: categoryBudgets,
           },
+          summary: current.summary
+            ? {
+                ...current.summary,
+                category_statuses: (current.summary.category_statuses ?? []).map((status) => (
+                  status.category_id === row.categoryId
+                    ? { ...status, monthly_limit: null }
+                    : status
+                )),
+              }
+            : current.summary,
         }
       })
       dirtyRowIdsRef.current.delete(row.id)
@@ -749,7 +769,6 @@ export default function PlannerView() {
           kind: 'expense',
         }).label} plan cleared for ${formatMonthPeriod(activeMonth)}.`,
       })
-      handleRetry()
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         handleAuthError()

--- a/nextjs/src/lib/apiClient.js
+++ b/nextjs/src/lib/apiClient.js
@@ -68,3 +68,34 @@ export async function apiPost(path, body, { accessToken, signal } = {}) {
 
   return responseBody
 }
+
+export async function apiDelete(path, { accessToken, signal } = {}) {
+  if (!accessToken) {
+    throw new ApiError('Missing access token', { status: 401 })
+  }
+
+  const response = await fetch(path, {
+    method: 'DELETE',
+    cache: 'no-store',
+    signal,
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+  })
+
+  let responseBody = null
+  try {
+    if (response.status !== 204) {
+      responseBody = await response.json()
+    }
+  } catch {}
+
+  if (!response.ok) {
+    throw new ApiError(responseBody?.error || 'Request failed', {
+      status: response.status,
+      body: responseBody,
+    })
+  }
+
+  return responseBody
+}

--- a/nextjs/src/lib/budget.js
+++ b/nextjs/src/lib/budget.js
@@ -188,6 +188,17 @@ export async function upsertCategoryBudgets(userId, month, categoryBudgets = [])
   return rows
 }
 
+export async function deleteCategoryBudget(userId, month, categoryId) {
+  const { rows } = await db.query(
+    `DELETE FROM public.category_budgets
+     WHERE user_id = $1 AND month = $2 AND category_id = $3
+     RETURNING category_id, month`,
+    [userId, month, categoryId]
+  )
+
+  return rows[0] ?? null
+}
+
 export async function getMonthlyTotals(userId, month) {
   const endMonth = nextMonth(month)
 

--- a/nextjs/src/lib/budget.js
+++ b/nextjs/src/lib/budget.js
@@ -85,8 +85,8 @@ export function isPositiveMoneyValue(value) {
   return Number.isFinite(amount) && amount > 0 && amount <= MAX_MONEY_VALUE
 }
 
-export async function getMonthlyBudget(userId, month) {
-  const { rows } = await db.query(
+export async function getMonthlyBudget(userId, month, queryable = db) {
+  const { rows } = await queryable.query(
     `SELECT month, monthly_limit, notified
      FROM public.budget_thresholds
      WHERE user_id = $1 AND month = $2`,
@@ -110,8 +110,8 @@ export async function getOwnedOrGlobalCategoriesByIds(userId, categoryIds = []) 
   return rows
 }
 
-export async function getCategoryBudgets(userId, month) {
-  const { rows } = await db.query(
+export async function getCategoryBudgets(userId, month, queryable = db) {
+  const { rows } = await queryable.query(
     `SELECT
        cb.category_id,
        cb.monthly_limit,
@@ -127,11 +127,9 @@ export async function getCategoryBudgets(userId, month) {
   return rows
 }
 
-export async function getMonthlyBudgetConfig(userId, month) {
-  const [budget, categoryBudgets] = await Promise.all([
-    getMonthlyBudget(userId, month),
-    getCategoryBudgets(userId, month),
-  ])
+export async function getMonthlyBudgetConfig(userId, month, queryable = db) {
+  const budget = await getMonthlyBudget(userId, month, queryable)
+  const categoryBudgets = await getCategoryBudgets(userId, month, queryable)
 
   if (!budget && !categoryBudgets.length) return null
 
@@ -188,8 +186,8 @@ export async function upsertCategoryBudgets(userId, month, categoryBudgets = [])
   return rows
 }
 
-export async function deleteCategoryBudget(userId, month, categoryId) {
-  const { rows } = await db.query(
+export async function deleteCategoryBudget(userId, month, categoryId, queryable = db) {
+  const { rows } = await queryable.query(
     `DELETE FROM public.category_budgets
      WHERE user_id = $1 AND month = $2 AND category_id = $3
      RETURNING category_id, month`,
@@ -197,6 +195,23 @@ export async function deleteCategoryBudget(userId, month, categoryId) {
   )
 
   return rows[0] ?? null
+}
+
+export async function clearCategoryBudgetConfig(userId, month, categoryId) {
+  const client = await db.connect()
+
+  try {
+    await client.query('BEGIN')
+    await deleteCategoryBudget(userId, month, categoryId, client)
+    const savedBudget = await getMonthlyBudgetConfig(userId, month, client)
+    await client.query('COMMIT')
+    return savedBudget
+  } catch (error) {
+    await client.query('ROLLBACK')
+    throw error
+  } finally {
+    client.release()
+  }
 }
 
 export async function getMonthlyTotals(userId, month) {

--- a/nextjs/src/lib/planner.js
+++ b/nextjs/src/lib/planner.js
@@ -4,6 +4,7 @@ import { buildCategoryBudgetHealth } from './budgetHealth'
 const UNCATEGORIZED_KEY = '__uncategorized__'
 const MAX_MONEY_CENTS = 9999999999n
 const MAX_EXPANDED_MONEY_LENGTH = 32
+const MONEY_DRAFT_PATTERN = /^[+]?(?:(\d+)(?:\.(\d*))?|\.(\d+))$/
 
 function expandScientificNotation(rawValue) {
   if (!/[eE]/.test(rawValue)) return rawValue
@@ -50,12 +51,10 @@ function parseMoneyAmount(value) {
 
   const integerDigits = match[2] ?? '0'
   const fractionDigits = match[3] ?? match[4] ?? ''
+  if (fractionDigits.length > 2) return null
+
   let cents = BigInt(integerDigits) * 100n
   cents += BigInt((fractionDigits.padEnd(2, '0').slice(0, 2)) || '0')
-
-  if ((fractionDigits[2] ?? '0') >= '5') {
-    cents += 1n
-  }
 
   if (cents <= 0n || cents > MAX_MONEY_CENTS) return null
   return Number(cents) / 100
@@ -99,6 +98,64 @@ export function areMoneyDraftValuesEquivalent(left, right) {
 
 export function normalizeMoneyDraftForSave(value) {
   return parseMoneyAmount(value)
+}
+
+export function getPlannerAmountDraftValidation(value, { hasSavedPlan = false } = {}) {
+  const rawValue = value == null ? '' : String(value).trim()
+
+  if (!rawValue) {
+    return {
+      isValid: false,
+      message: '',
+      kind: 'empty',
+    }
+  }
+
+  if (rawValue.startsWith('-')) {
+    return {
+      isValid: false,
+      message: 'Amount cannot be negative.',
+      kind: 'negative',
+    }
+  }
+
+  const plainValue = expandScientificNotation(rawValue) ?? rawValue
+  const moneyDraftMatch = plainValue.match(MONEY_DRAFT_PATTERN)
+  const fractionDigits = moneyDraftMatch?.[2] ?? moneyDraftMatch?.[3] ?? ''
+  if (moneyDraftMatch && fractionDigits.length > 2) {
+    return {
+      isValid: false,
+      message: 'Enter a dollar amount with no more than 2 decimal places.',
+      kind: 'too_many_decimals',
+    }
+  }
+
+  const normalizedValue = normalizeMoneyDraftForSave(rawValue)
+  if (normalizedValue != null) {
+    return {
+      isValid: true,
+      message: '',
+      kind: 'valid',
+      amount: normalizedValue,
+    }
+  }
+
+  const numericValue = Number(rawValue)
+  if (Number.isFinite(numericValue) && numericValue === 0) {
+    return {
+      isValid: false,
+      message: hasSavedPlan
+        ? 'Use Clear plan to return this category to Not set.'
+        : 'Enter an amount greater than $0.',
+      kind: 'zero',
+    }
+  }
+
+  return {
+    isValid: false,
+    message: 'Enter a valid dollar amount.',
+    kind: 'malformed',
+  }
 }
 
 export function buildPlannerRows({

--- a/nextjs/src/lib/planner.js
+++ b/nextjs/src/lib/planner.js
@@ -4,7 +4,7 @@ import { buildCategoryBudgetHealth } from './budgetHealth'
 const UNCATEGORIZED_KEY = '__uncategorized__'
 const MAX_MONEY_CENTS = 9999999999n
 const MAX_EXPANDED_MONEY_LENGTH = 32
-const MONEY_DRAFT_PATTERN = /^[+]?(?:(\d+)(?:\.(\d*))?|\.(\d+))$/
+const MONEY_AMOUNT_PATTERN = /^([+-])?(?:(\d+)(?:\.(\d*))?|\.(\d+))$/
 
 function expandScientificNotation(rawValue) {
   if (!/[eE]/.test(rawValue)) return rawValue
@@ -42,15 +42,12 @@ function parseMoneyAmount(value) {
   const rawValue = String(value).trim()
   if (!rawValue) return null
 
-  const plainValue = expandScientificNotation(rawValue) ?? rawValue
-  const match = plainValue.match(/^([+-])?(?:(\d+)(?:\.(\d*))?|\.(\d+))$/)
-  if (!match) return null
+  const draftParts = parseMoneyDraftParts(rawValue)
+  if (!draftParts) return null
 
-  const sign = match[1]
+  const { sign, integerDigits, fractionDigits } = draftParts
   if (sign === '-') return null
 
-  const integerDigits = match[2] ?? '0'
-  const fractionDigits = match[3] ?? match[4] ?? ''
   if (fractionDigits.length > 2) return null
 
   let cents = BigInt(integerDigits) * 100n
@@ -58,6 +55,18 @@ function parseMoneyAmount(value) {
 
   if (cents <= 0n || cents > MAX_MONEY_CENTS) return null
   return Number(cents) / 100
+}
+
+function parseMoneyDraftParts(rawValue) {
+  const plainValue = expandScientificNotation(rawValue) ?? rawValue
+  const match = plainValue.match(MONEY_AMOUNT_PATTERN)
+  if (!match) return null
+
+  return {
+    sign: match[1] ?? '',
+    integerDigits: match[2] ?? '0',
+    fractionDigits: match[3] ?? match[4] ?? '',
+  }
 }
 
 function parseSpendAmount(value) {
@@ -119,10 +128,8 @@ export function getPlannerAmountDraftValidation(value, { hasSavedPlan = false } 
     }
   }
 
-  const plainValue = expandScientificNotation(rawValue) ?? rawValue
-  const moneyDraftMatch = plainValue.match(MONEY_DRAFT_PATTERN)
-  const fractionDigits = moneyDraftMatch?.[2] ?? moneyDraftMatch?.[3] ?? ''
-  if (moneyDraftMatch && fractionDigits.length > 2) {
+  const moneyDraftParts = parseMoneyDraftParts(rawValue)
+  if (moneyDraftParts && moneyDraftParts.fractionDigits.length > 2) {
     return {
       isValid: false,
       message: 'Enter a dollar amount with no more than 2 decimal places.',

--- a/nextjs/src/lib/planner.js
+++ b/nextjs/src/lib/planner.js
@@ -4,6 +4,7 @@ import { buildCategoryBudgetHealth } from './budgetHealth'
 const UNCATEGORIZED_KEY = '__uncategorized__'
 const MAX_MONEY_CENTS = 9999999999n
 const MAX_EXPANDED_MONEY_LENGTH = 32
+const MAX_MONEY_INTEGER_DIGITS = 8
 const MONEY_AMOUNT_PATTERN = /^([+-])?(?:(\d+)(?:\.(\d*))?|\.(\d+))$/
 
 function expandScientificNotation(rawValue) {
@@ -48,9 +49,12 @@ function parseMoneyAmount(value) {
   const { sign, integerDigits, fractionDigits } = draftParts
   if (sign === '-') return null
 
+  const normalizedIntegerDigits = integerDigits.replace(/^0+/, '') || '0'
+  if (normalizedIntegerDigits.length > MAX_MONEY_INTEGER_DIGITS) return null
+
   if (fractionDigits.length > 2) return null
 
-  let cents = BigInt(integerDigits) * 100n
+  let cents = BigInt(normalizedIntegerDigits) * 100n
   cents += BigInt((fractionDigits.padEnd(2, '0').slice(0, 2)) || '0')
 
   if (cents <= 0n || cents > MAX_MONEY_CENTS) return null


### PR DESCRIPTION
## Description
Adds an explicit Planner flow for clearing a saved category plan back to `Not set`, backed by a scoped `DELETE /api/budget` path that removes only the selected category budget row for the authenticated user/month/category.

Also improves Planner amount validation feedback for invalid drafts, including negative values, zero values, malformed input, and too many decimal places. Positive category budget saves remain unchanged.

## Related User Story / Issue
Fixes #99

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [ ] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes
Verified locally with:

cd nextjs
npx jest __tests__/budget.test.js __tests__/lib.planner.test.js __tests__/frontend/planner.test.js __tests__/apiClient.test.js --runInBand
npm run build

Results:
- Focused Jest suite passed: 4 test suites, 88 tests.
- Production build completed successfully.

Coverage includes:
- Clearing one category budget without removing other category plans.
- Idempotent clear behavior when the row is already missing.
- Validation for invalid month/category IDs and non-owned/non-global categories.
- Planner inline validation for negative, malformed, zero, and extra-decimal drafts.
- Preserving positive decimal category budget saves.
- API client DELETE helper behavior.

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Notes for Reviewers
The clear behavior intentionally deletes the category budget row instead of storing `monthly_limit: 0`, because the existing database constraint requires positive category budget amounts and the app already represents no-budget state as no row / `Not set`.

The audited implementation also validates that the category is owned by the user or global before attempting deletion, adds accessible validation wiring with `aria-invalid`/`aria-describedby`, and rejects extra decimal places instead of silently rounding category plan drafts.

This is scoped to Planner category plans only. It does not change overall monthly cap clearing, savings goals, transactions, auth/account, recurring behavior, dependencies, package-lock, or database migrations.

## Checklist
- [x] Linked to a user story or issue
- [ ] Code builds / tests pass in CI
- [x] Ready for review
