### PR TITLE
fix: prevent invalid dashboard budget drafts while typing

### DIFF
--- a/nextjs/__tests__/frontend/dashboard-view.test.js
+++ b/nextjs/__tests__/frontend/dashboard-view.test.js
@@ -1043,11 +1043,10 @@ describe('DashboardView', () => {
     })
     expect(screen.getByText(/Monthly spending limit for/i)).toBeTruthy()
     expect(screen.getAllByText(TEST_CURRENT_MONTH).length).toBeGreaterThan(0)
-    expect(screen.getByRole('spinbutton').getAttribute('min')).toBe('0.01')
-    expect(screen.getByRole('spinbutton').getAttribute('step')).toBe('0.01')
+    expect(screen.getByLabelText('Monthly limit ($)').getAttribute('inputmode')).toBe('decimal')
 
     await act(async () => {
-      fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '49.23' } })
+      fireEvent.change(screen.getByLabelText('Monthly limit ($)'), { target: { value: '49.23' } })
       await flushAsyncUpdates()
     })
 
@@ -1067,7 +1066,7 @@ describe('DashboardView', () => {
     expect(screen.queryByText(/Current limit:/)).toBeNull()
   })
 
-  it('shows app validation instead of saving budget drafts with more than two decimals', async () => {
+  it('shows app validation instead of saving incomplete trailing-decimal drafts', async () => {
     apiGet
       .mockResolvedValueOnce(createLiveSummary({
         monthly_limit: '1000.00',
@@ -1094,11 +1093,11 @@ describe('DashboardView', () => {
       await flushAsyncUpdates()
     })
 
-    const budgetInput = screen.getByRole('spinbutton')
+    const budgetInput = screen.getByLabelText('Monthly limit ($)')
     expect(budgetInput.form.noValidate).toBe(true)
 
     await act(async () => {
-      fireEvent.change(budgetInput, { target: { value: '3.235' } })
+      fireEvent.change(budgetInput, { target: { value: '3.' } })
       await flushAsyncUpdates()
     })
 
@@ -1110,5 +1109,54 @@ describe('DashboardView', () => {
     expect(screen.getByRole('alert').textContent).toBe('Monthly limit must be a positive dollar amount with up to 2 decimal places.')
     expect(apiPost).not.toHaveBeenCalled()
     expect(apiGet).toHaveBeenCalledTimes(6)
+  })
+
+  it('blocks malformed monthly budget drafts while typing', async () => {
+    apiGet
+      .mockResolvedValueOnce(createLiveSummary({
+        monthly_limit: '1000.00',
+        total_budget: '1000.00',
+        total_expenses: '400.00',
+        total_income: '1500.00',
+        remaining_budget: '600.00',
+        threshold_exceeded: false,
+        category_statuses: [],
+      }))
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: { active_count: 0, available_after_goal_contributions: null },
+      })
+
+    await renderDashboard()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Edit budget' }))
+      await flushAsyncUpdates()
+    })
+
+    const budgetInput = screen.getByLabelText('Monthly limit ($)')
+    expect(budgetInput.value).toBe('1000.00')
+
+    await act(async () => {
+      fireEvent.change(budgetInput, { target: { value: '-5' } })
+      await flushAsyncUpdates()
+    })
+    expect(budgetInput.value).toBe('1000.00')
+
+    await act(async () => {
+      fireEvent.change(budgetInput, { target: { value: '49.234' } })
+      await flushAsyncUpdates()
+    })
+    expect(budgetInput.value).toBe('1000.00')
+
+    await act(async () => {
+      fireEvent.change(budgetInput, { target: { value: '49.23' } })
+      await flushAsyncUpdates()
+    })
+    expect(budgetInput.value).toBe('49.23')
   })
 })

--- a/nextjs/src/components/dashboard-view.js
+++ b/nextjs/src/components/dashboard-view.js
@@ -63,6 +63,7 @@ import TransactionDetailSheet from '@/components/ui/TransactionDetailSheet'
 
 const ACTIVITY_PREVIEW_LIMIT = 6
 const BUDGET_DRAFT_VALIDATION_MESSAGE = 'Monthly limit must be a positive dollar amount with up to 2 decimal places.'
+const BUDGET_DRAFT_INPUT_PATTERN = /^\d*(?:\.\d{0,2})?$/
 const BUDGET_DRAFT_PATTERN = /^(?:\d+(?:\.\d{1,2})?|\.\d{1,2})$/
 
 export {
@@ -92,6 +93,10 @@ export function getBudgetDraftValidationMessage(value) {
   }
 
   return ''
+}
+
+function isValidBudgetDraftInput(value) {
+  return value === '' || BUDGET_DRAFT_INPUT_PATTERN.test(value)
 }
 
 function LiveNotice({ message, onRetry }) {
@@ -686,14 +691,13 @@ export default function DashboardView() {
                 <input
                   className="input-field"
                   inputMode="decimal"
-                  min="0.01"
                   onChange={(event) => {
+                    if (!isValidBudgetDraftInput(event.target.value)) return
                     setBudgetDraft({ monthly_limit: event.target.value })
                     if (budgetSaveError) setBudgetSaveError('')
                   }}
                   placeholder="e.g. 2000"
-                  step="0.01"
-                  type="number"
+                  type="text"
                   value={budgetDraft.monthly_limit}
                 />
               </label>


### PR DESCRIPTION
## Description
Prevents malformed monthly budget drafts from being entered in the dashboard budget form while typing.

The dashboard budget field now blocks invalid draft input such as negative signs and values with more than two decimal places. Submit-time validation is still preserved for incomplete drafts like `3.`.

## Related User Story / Issue
Closes #113

## Type of Change
- [x] Bug fix
- [x] UI change
- [x] Test

### Test Notes
Verified locally with:

- `npm test -- --runTestsByPath __tests__/frontend/dashboard-view.test.js`

Results:
- Focused dashboard suite passed: 43 tests

### What changed
- Updated the dashboard monthly budget input to reject malformed drafts while typing
- Kept existing submit-time validation for incomplete drafts
- Added focused regression coverage in `__tests__/frontend/dashboard-view.test.js`

## UI Changes (if applicable)
- [x] UI updated

## Notes for Reviewers
This is scoped to the dashboard monthly budget form only. The change keeps valid positive money drafts working while preventing malformed values such as negative signs and over-precision input from entering the draft state.

## Checklist
- [x] Linked to a user story or issue
- [x] Code builds / tests pass locally
- [x] Ready for review