### PR TITLE
Fix disabled button cursors for unavailable actions

### DIFF
--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -434,7 +434,7 @@ html[data-theme='dark'] .auth-shell__glow--right {
 .button-secondary:disabled,
 .auth-theme-toggle__button:disabled,
 .theme-toggle__button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.7;
   transform: none;
 }
@@ -464,7 +464,7 @@ html[data-theme='dark'] .auth-shell__glow--right {
 }
 
 .button-danger:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.7;
   transform: none;
 }

--- a/scripts/create-preview-branch.sh
+++ b/scripts/create-preview-branch.sh
@@ -19,8 +19,37 @@ suf=${GITHUB_SHA:+${GITHUB_SHA:0:7}}
 suf=${suf:-$(date +%s)-$RANDOM}
 name=budgetbuddy-ci-${rid}-${att}-${suf}
 
-supabase branches create "$name" --project-ref "$ref" --experimental --yes >/dev/null
-json=$(supabase branches get "$name" --project-ref "$ref" --experimental -o json)
+create_log=$(mktemp "${RUNNER_TEMP:-/tmp}/preview-create-XXXXXXXXXX")
+get_log=$(mktemp "${RUNNER_TEMP:-/tmp}/preview-get-XXXXXXXXXX")
+
+if ! supabase branches create "$name" --project-ref "$ref" --experimental --yes >"$create_log" 2>&1; then
+  if grep -qi 'Preview branch not found\|unexpected find branch status 404' "$create_log"; then
+    echo "Preview branch create reported a transient 404; polling for branch details." >&2
+  else
+    cat "$create_log" >&2
+    exit 1
+  fi
+fi
+
+json=''
+for attempt in {1..30}; do
+  if json=$(supabase branches get "$name" --project-ref "$ref" --experimental -o json 2>"$get_log"); then
+    if jq -e '.POSTGRES_URL and .SUPABASE_URL and .SUPABASE_ANON_KEY and .SUPABASE_SERVICE_ROLE_KEY' <<<"$json" >/dev/null; then
+      break
+    fi
+  elif ! grep -qi 'Preview branch not found\|unexpected find branch status 404' "$get_log"; then
+    cat "$get_log" >&2
+    exit 1
+  fi
+
+  if [[ $attempt -eq 30 ]]; then
+    cat "$get_log" >&2
+    echo "Timed out waiting for preview branch details: $name" >&2
+    exit 1
+  fi
+
+  sleep 3
+done
 
 db=$(jq -r '.POSTGRES_URL' <<<"$json")
 url=$(jq -r '.SUPABASE_URL' <<<"$json")


### PR DESCRIPTION
## Description
Updates shared disabled button styling so unavailable actions use the normal disabled cursor instead of a wait/loading cursor. This keeps invalid, sample-only, and otherwise unavailable actions from looking like the app is busy or stuck.

## Related User Story / Issue
Fixes #118

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [ ] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes
Verified locally with:
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

Also checked computed cursor styles for disabled Dashboard, Planner, Transactions, and danger button states. Disabled actions now resolve to `cursor: not-allowed`, while saving/loading states continue to rely on visible text such as `Saving...`, `Copying...`, and `Exporting...`.

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Notes for Reviewers
This is intentionally scoped to shared CSS only. 

Note: this PR also includes a small `scripts/create-preview-branch.sh` CI fix so App CI retries the temporary Supabase “preview branch not found” response instead of failing before tests run.

## Checklist
- [x] Linked to a user story or issue
- [ ] Code builds / tests pass in CI
- [x] Ready for review
