### PR TITLE
add post-deploy smoke check to Vercel deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,10 +50,17 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Deploy to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          DEPLOYED_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "DEPLOYED_URL=$DEPLOYED_URL" >> $GITHUB_ENV
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      - name: Post-deploy smoke check
+        run: |
+          echo "Checking deployment at: $DEPLOYED_URL"
+          curl --fail --silent --show-error --location "$DEPLOYED_URL"


### PR DESCRIPTION
Description: Resolves: "add post-deploy smoke check to Vercel deployment workflow"

Context
Currently, our GitHub Actions workflow deploys the application to Vercel but doesn't actively verify if the deployed URL is actually alive and healthy. This PR adds a lightweight, automated smoke check to catch failed or unhealthy deployments immediately.

Changes Made
Captured Live URL: Updated the Deploy to Vercel step to dynamically capture the deployed URL output from the Vercel CLI and store it in $GITHUB_ENV.
Added Smoke Check Step: Appended a Post-deploy smoke check step directly after deployment.
Automated Failure: Implemented a curl --fail --silent --show-error --location "$DEPLOYED_URL" command. This natively forces the GitHub Actions job to fail if the app is unreachable or returns a bad HTTP response (e.g., 404, 500).
Clear Logging: Added an echo statement to log the URL being checked without leaking any sensitive tokens.
Impact & Scope
Strictly Scoped: Zero changes were made to application code or the existing CI/CD infrastructure. Existing deployment environments, variables, and secrets remain entirely untouched.
Lightweight: Did not introduce any heavy testing frameworks (like Playwright or Cypress). The check is handled cleanly via native shell commands.