### PR TITLE
Add Insights budget CTA to Planner month flow

### DIFF
--- a/nextjs/__tests__/frontend/app/(app)/planner/page.unit.test.js
+++ b/nextjs/__tests__/frontend/app/(app)/planner/page.unit.test.js
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+
+jest.mock('@/components/planner-view', () => jest.fn(() => null))
+
+const React = require('react')
+const PlannerView = require('@/components/planner-view')
+const PlannerPage = require('@/app/(app)/planner/page').default
+
+describe('PlannerPage search params', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('passes the month query string to PlannerView', () => {
+    const element = PlannerPage({ searchParams: { month: '2026-04' } })
+
+    expect(element).toEqual(React.createElement(PlannerView, { initialMonth: '2026-04' }))
+  })
+
+  it('uses the first month query value when Next provides an array', () => {
+    const element = PlannerPage({ searchParams: { month: ['2026-04', '2026-05'] } })
+
+    expect(element).toEqual(React.createElement(PlannerView, { initialMonth: '2026-04' }))
+  })
+
+  it('passes undefined when no month query is present', () => {
+    const element = PlannerPage({ searchParams: {} })
+
+    expect(element).toEqual(React.createElement(PlannerView, { initialMonth: undefined }))
+  })
+})

--- a/nextjs/__tests__/frontend/components/insights-view.test.js
+++ b/nextjs/__tests__/frontend/components/insights-view.test.js
@@ -176,6 +176,7 @@ describe('InsightsView (sample data)', () => {
 
     const link = screen.getByRole('link', { name: 'Manage March 2026 budget in Planner' })
     expect(link.getAttribute('href')).toBe('/planner?month=2026-03')
+    expect(link.textContent).toBe('Manage selected month\'s budget')
     expect(link.closest('.insights-v57__budget-overview')).toBeTruthy()
   })
 

--- a/nextjs/__tests__/frontend/components/insights-view.test.js
+++ b/nextjs/__tests__/frontend/components/insights-view.test.js
@@ -171,6 +171,14 @@ describe('InsightsView (sample data)', () => {
     expect(container.querySelector('.insights-v57__cashflow-peak')).toBeTruthy()
   })
 
+  it('renders the budget management CTA in the budget health area', () => {
+    render(React.createElement(InsightsView))
+
+    const link = screen.getByRole('link', { name: 'Manage March 2026 budget in Planner' })
+    expect(link.getAttribute('href')).toBe('/planner?month=2026-03')
+    expect(link.closest('.insights-v57__budget-overview')).toBeTruthy()
+  })
+
   it('renders the new Category detail section with CategoryProgressRow items and a pace-vs-last-month chart', () => {
     const { container } = render(React.createElement(InsightsView))
 
@@ -290,6 +298,33 @@ describe('InsightsView CSV export', () => {
       expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:csv')
     }, { timeout: 3000 })
     await waitFor(() => expect(screen.getByText('CSV export downloaded.')).toBeTruthy())
+  })
+
+  it('points the no-budget CTA to Planner with the selected month', async () => {
+    render(React.createElement(InsightsView))
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        '/api/insights?month=2026-03-01',
+        expect.objectContaining({ accessToken: 'live-token' })
+      )
+    })
+
+    const marchLink = screen.getByRole('link', { name: 'Manage March 2026 budget in Planner' })
+    expect(marchLink.getAttribute('href')).toBe('/planner?month=2026-03')
+    expect(marchLink.closest('.insights-v57__budget-overview')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to February 2026' }))
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        '/api/insights?month=2026-02-01',
+        expect.objectContaining({ accessToken: 'live-token' })
+      )
+    })
+
+    const februaryLink = screen.getByRole('link', { name: 'Manage February 2026 budget in Planner' })
+    expect(februaryLink.getAttribute('href')).toBe('/planner?month=2026-02')
   })
 
   it('uses sanitized filenames from Content-Disposition before downloading', async () => {

--- a/nextjs/__tests__/frontend/components/planner-view.test.js
+++ b/nextjs/__tests__/frontend/components/planner-view.test.js
@@ -224,10 +224,80 @@ describe('PlannerView', () => {
     expect(screen.getAllByText('2026-02-01').length).toBeGreaterThan(0)
   })
 
+  it('normalizes a valid full-date month query param to that month start', async () => {
+    apiGet
+      .mockResolvedValueOnce([
+        { id: 'cat-food', name: 'Food', icon: null },
+      ])
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: '800.00',
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: '800.00',
+        total_budget: '800.00',
+        total_expenses: '120.00',
+        total_income: '900.00',
+        remaining_budget: '680.00',
+        threshold_exceeded: false,
+        category_statuses: [],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-01-01',
+        monthly_limit: null,
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: {
+          active_count: 0,
+          current_total: '0.00',
+          remaining_total: '0.00',
+          monthly_required_total: '0.00',
+          available_after_goal_contributions: null,
+          pressure_level: 'none',
+        },
+      })
+
+    await renderPlanner({ initialMonth: '2026-02-14' })
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget?month=2026-02-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/savings-goals?month=2026-02-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(routerReplace).toHaveBeenCalledWith('/planner', { scroll: false })
+    expect(screen.getAllByText('2026-02-01').length).toBeGreaterThan(0)
+  })
+
   it('ignores invalid month query params and keeps the default month behavior', async () => {
     mockPlannerResponses()
 
     await renderPlanner({ initialMonth: '2026-13' })
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget?month=2026-03-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/savings-goals?month=2026-03-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(routerReplace).toHaveBeenCalledWith('/planner', { scroll: false })
+    expect(screen.getAllByText('2026-03-01').length).toBeGreaterThan(0)
+  })
+
+  it('rejects invalid full-date month query params and falls back to the default month', async () => {
+    mockPlannerResponses()
+
+    await renderPlanner({ initialMonth: '2026-02-30' })
 
     await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
     expect(apiGet).toHaveBeenCalledWith(

--- a/nextjs/__tests__/frontend/components/planner-view.test.js
+++ b/nextjs/__tests__/frontend/components/planner-view.test.js
@@ -69,15 +69,17 @@ const { useAuth, useDataChanged, useDataMode } = require('@/components/providers
 const { ApiError, apiDelete, apiGet, apiPost } = require('@/lib/apiClient')
 const PlannerView = require('@/components/planner-view').default
 
+let routerReplace
+
 async function flushAsyncUpdates() {
   await Promise.resolve()
   await Promise.resolve()
 }
 
-async function renderPlanner() {
+async function renderPlanner(props = {}) {
   let result
   await act(async () => {
-    result = render(React.createElement(PlannerView))
+    result = render(React.createElement(PlannerView, props))
     await flushAsyncUpdates()
   })
   return result
@@ -85,7 +87,8 @@ async function renderPlanner() {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  useRouter.mockReturnValue({ replace: jest.fn() })
+  routerReplace = jest.fn()
+  useRouter.mockReturnValue({ replace: routerReplace })
   useAuth.mockReturnValue({
     isReady: true,
     logout: jest.fn(),
@@ -140,6 +143,104 @@ describe('PlannerView', () => {
         },
       })
   }
+
+  it('loads the default current month when opened without a month query', async () => {
+    mockPlannerResponses()
+
+    await renderPlanner()
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget?month=2026-03-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget/summary?month=2026-03-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(routerReplace).not.toHaveBeenCalled()
+    expect(screen.getByText('Selected month')).toBeTruthy()
+    expect(screen.getAllByText('2026-03-01').length).toBeGreaterThan(0)
+  })
+
+  it('initializes to a valid month query param and removes the consumed query from the URL', async () => {
+    apiGet
+      .mockResolvedValueOnce([
+        { id: 'cat-food', name: 'Food', icon: null },
+      ])
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: '800.00',
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-02-01',
+        monthly_limit: '800.00',
+        total_budget: '800.00',
+        total_expenses: '120.00',
+        total_income: '900.00',
+        remaining_budget: '680.00',
+        threshold_exceeded: false,
+        category_statuses: [],
+      })
+      .mockResolvedValueOnce({
+        month: '2026-01-01',
+        monthly_limit: null,
+        category_budgets: [],
+      })
+      .mockResolvedValueOnce({
+        goals: [],
+        summary: {
+          active_count: 0,
+          current_total: '0.00',
+          remaining_total: '0.00',
+          monthly_required_total: '0.00',
+          available_after_goal_contributions: null,
+          pressure_level: 'none',
+        },
+      })
+
+    await renderPlanner({ initialMonth: '2026-02' })
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget?month=2026-02-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget/summary?month=2026-02-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget?month=2026-01-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/savings-goals?month=2026-02-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(routerReplace).toHaveBeenCalledWith('/planner', { scroll: false })
+    expect(screen.getByText('Selected month')).toBeTruthy()
+    expect(screen.getAllByText('2026-02-01').length).toBeGreaterThan(0)
+  })
+
+  it('ignores invalid month query params and keeps the default month behavior', async () => {
+    mockPlannerResponses()
+
+    await renderPlanner({ initialMonth: '2026-13' })
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(5))
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/budget?month=2026-03-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/savings-goals?month=2026-03-01',
+      expect.objectContaining({ accessToken: 'test-token' })
+    )
+    expect(routerReplace).toHaveBeenCalledWith('/planner', { scroll: false })
+    expect(screen.getAllByText('2026-03-01').length).toBeGreaterThan(0)
+  })
 
   it('renders monthly health from category budgets when no explicit overall cap exists', async () => {
     apiGet

--- a/nextjs/src/app/(app)/planner/page.js
+++ b/nextjs/src/app/(app)/planner/page.js
@@ -4,6 +4,6 @@ export const metadata = {
   title: 'Planner',
 }
 
-export default function PlannerPage() {
-  return <PlannerView />
+export default function PlannerPage({ searchParams }) {
+  return <PlannerView initialMonth={searchParams?.month} />
 }

--- a/nextjs/src/app/(app)/planner/page.js
+++ b/nextjs/src/app/(app)/planner/page.js
@@ -4,6 +4,10 @@ export const metadata = {
   title: 'Planner',
 }
 
+function getFirstSearchParamValue(value) {
+  return Array.isArray(value) ? value[0] : value
+}
+
 export default function PlannerPage({ searchParams }) {
-  return <PlannerView initialMonth={searchParams?.month} />
+  return <PlannerView initialMonth={getFirstSearchParamValue(searchParams?.month)} />
 }

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -8301,6 +8301,17 @@ html[data-theme='dark'] .insights-screen--issue57 {
   font-size: 0.98rem;
 }
 
+.insights-screen--issue57 .insights-v57__budget-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: center;
+  width: min(100%, 18rem);
+  padding: 0 1rem;
+  text-align: center;
+  text-decoration: none;
+}
+
 .insights-screen--issue57 .insights-v57__budget-panels {
   display: grid;
   grid-template-columns: 1fr;

--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -298,6 +298,7 @@ export default function InsightsView() {
   const previousDisabled = isSampleMode || !earliestMonth || activeMonth <= earliestMonth
   const nextDisabled = isSampleMode || activeMonth >= currentLiveMonth
   const activeMonthLabel = formatMonthLabel(activeMonth)
+  const plannerBudgetHref = `/planner?month=${encodeURIComponent(activeMonth.slice(0, 7))}`
   const activeTotal = useMemo(() => (
     activeItems.reduce((sum, item) => sum + Number(item.amount ?? 0), 0)
   ), [activeItems])
@@ -784,6 +785,13 @@ export default function InsightsView() {
                 <span>{(budgetHealth.remainingAmount ?? 0) < 0 ? 'Over' : 'Left'} <strong>{budgetHealth.remainingAmount == null ? 'None' : formatCurrency(Math.abs(budgetHealth.remainingAmount))}</strong></span>
                 <span>Budget <strong>{budgetHealth.budgetAmount == null ? 'None' : formatCurrency(budgetHealth.budgetAmount)}</strong></span>
               </div>
+              <Link
+                aria-label={`Manage ${activeMonthLabel} budget in Planner`}
+                className="button-secondary insights-v57__budget-cta"
+                href={plannerBudgetHref}
+              >
+                Manage this month&apos;s budget
+              </Link>
             </div>
 
             <div className="insights-v57__budget-panels">

--- a/nextjs/src/components/insights-view.js
+++ b/nextjs/src/components/insights-view.js
@@ -790,7 +790,7 @@ export default function InsightsView() {
                 className="button-secondary insights-v57__budget-cta"
                 href={plannerBudgetHref}
               >
-                Manage this month&apos;s budget
+                Manage selected month&apos;s budget
               </Link>
             </div>
 

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -176,6 +176,18 @@ const GOAL_ICON_OPTIONS = [
 const GOAL_FORM_CLOSE_MS = 230
 const GOAL_ICON_PICKER_CLOSE_MS = 140
 
+function normalizePlannerMonthQuery(value) {
+  if (typeof value !== 'string') return null
+
+  const match = value.trim().match(/^(\d{4})-(\d{2})(?:-01)?$/)
+  if (!match) return null
+
+  const monthNumber = Number(match[2])
+  if (monthNumber < 1 || monthNumber > 12) return null
+
+  return `${match[1]}-${match[2]}-01`
+}
+
 function getMotionSafeDuration(duration) {
   if (
     typeof window !== 'undefined'
@@ -198,12 +210,14 @@ function getGoalFormDefaults(goal = null) {
   }
 }
 
-export default function PlannerView() {
+export default function PlannerView({ initialMonth = null }) {
   const router = useRouter()
   const { isReady, logout, session } = useAuth()
   const { isSampleMode } = useDataMode()
   const { notifyDataChanged } = useDataChanged()
-  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonthStart)
+  const queryMonth = useMemo(() => normalizePlannerMonthQuery(initialMonth), [initialMonth])
+  const hasInitialMonthParam = typeof initialMonth === 'string' && initialMonth.trim() !== ''
+  const [selectedMonth, setSelectedMonth] = useState(() => queryMonth ?? getCurrentMonthStart())
   const [reloadToken, setReloadToken] = useState(0)
   const [liveState, setLiveState] = useState({
     month: null,
@@ -235,6 +249,7 @@ export default function PlannerView() {
   const isOverallDirtyRef = useRef(false)
   const rowDraftsRef = useRef({})
   const overallDraftRef = useRef('')
+  const appliedQueryMonthRef = useRef(queryMonth)
   const goalIconPickerRef = useRef(null)
   const goalIconButtonRef = useRef(null)
   const goalCtaRef = useRef(null)
@@ -245,6 +260,17 @@ export default function PlannerView() {
   const shouldFocusGoalCtaAfterCloseRef = useRef(false)
 
   const activeMonth = isSampleMode ? DEMO_MONTH : selectedMonth
+
+  useEffect(() => {
+    if (!queryMonth || appliedQueryMonthRef.current === queryMonth) return
+    appliedQueryMonthRef.current = queryMonth
+    setSelectedMonth(queryMonth)
+  }, [queryMonth])
+
+  useEffect(() => {
+    if (!hasInitialMonthParam) return
+    router.replace('/planner', { scroll: false })
+  }, [hasInitialMonthParam, router])
 
   const finishGoalIconPickerClose = () => {
     if (!isGoalIconPickerClosingRef.current) return

--- a/nextjs/src/components/planner-view.js
+++ b/nextjs/src/components/planner-view.js
@@ -179,11 +179,16 @@ const GOAL_ICON_PICKER_CLOSE_MS = 140
 function normalizePlannerMonthQuery(value) {
   if (typeof value !== 'string') return null
 
-  const match = value.trim().match(/^(\d{4})-(\d{2})(?:-01)?$/)
+  const match = value.trim().match(/^(\d{4})-(\d{2})(?:-(\d{2}))?$/)
   if (!match) return null
 
+  const year = Number(match[1])
   const monthNumber = Number(match[2])
-  if (monthNumber < 1 || monthNumber > 12) return null
+  const dayNumber = match[3] == null ? 1 : Number(match[3])
+  if (year < 1000 || monthNumber < 1 || monthNumber > 12 || dayNumber < 1) return null
+
+  const lastDayOfMonth = new Date(Date.UTC(year, monthNumber, 0, 12)).getUTCDate()
+  if (dayNumber > lastDayOfMonth) return null
 
   return `${match[1]}-${match[2]}-01`
 }


### PR DESCRIPTION
## Description
Adds a small path from Insights budget health to Planner so users can manage the budget for the month selected in Insights.

Insights now shows a “Manage this month’s budget” CTA in the budget health area. The CTA links to `/planner?month=YYYY-MM`. Planner consumes a valid `month` query param to initialize the selected month, then replaces the URL with `/planner` so the address bar does not become stale when users change months inside Planner.

## Related User Story / Issue
Fixes #119

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Backend / API change
- [x] UI change
- [ ] Database change
- [ ] Documentation
- [ ] Refactor

## How Has This Been Tested?
- [ ] GitHub Actions / CI tests passed
- [x] Manual testing performed
- [ ] Not tested locally

### Test Notes
Verified with:
- `npm test -- --runInBand __tests__/frontend/components/planner-view.test.js __tests__/frontend/components/insights-view.test.js`
- `npm test -- --runInBand`
- `npm run build`
- `git diff --check`

Manual QA confirmed:
- Insights CTA links to Planner with the selected month context.
- Planner initializes from `/planner?month=YYYY-MM`.
- Planner removes the consumed query param so month navigation does not leave a stale URL.
- Normal `/planner` behavior still works.
- Invalid month query params fall back to default Planner behavior.

## UI Changes (if applicable)
- [ ] No UI changes
- [x] UI updated (add screenshots if needed)

## Notes for Reviewers
This is intentionally URL-based and scoped to the existing Planner flow. Insights does not edit budgets directly, and no budget API behavior changed.
The Planner `month` query is treated as an entry-point initializer, then cleaned from the URL to avoid stale address-bar state after using Planner’s own month controls.

## Checklist
- [x] Linked to a user story or issue
- [x] Code builds / tests pass in CI
- [x] Ready for review